### PR TITLE
feat(bmad_v6): DB selection reference + anti-slop frontend checklist (1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [1.2.0] — 2026-07-03
+
+### Added
+
+- **Database selection reference for the Architect.** `references/db-selection-reference.md` —
+  a PACELC-classified comparison of 15 databases (Cassandra, MongoDB, DynamoDB, CockroachDB,
+  Spanner, PostgreSQL, Redis, etcd, Riak, Neo4j, Elasticsearch, FoundationDB, ScyllaDB,
+  Couchbase, YugabyteDB) with use cases and refactor-risk notes. `architect.md` loads it only
+  when a feature introduces a new datastore or an existing one takes on a materially different
+  use case — not part of every Architecture Document.
+- **Frontend design-quality checklist (anti-AI-slop).** `references/frontend-design-reference.md`,
+  condensed from [Impeccable](https://github.com/pbakaus/impeccable) (Apache 2.0): absolute
+  bans (gradient text, glassmorphism-as-default, side-stripe borders, identical card grids,
+  eyebrow-on-every-section, etc.) plus color/typography/layout/motion rules. `coder-frontend.md`
+  carries the hard-ban shortlist inline and loads the full reference only for stories that
+  create or materially redesign visual surface. Quinn's frontend audit lens (`qa.md`)
+  spot-checks the same bans as a MINOR/aesthetic finding, never a gate blocker.
+- **`/frontend-design` dispatch wired into the task and epic pipelines.** Before dispatching
+  the frontend coder on a story that creates/redesigns visual surface,
+  `multi-agent-coding-pipeline` and `task-coding-pipeline` now invoke Anthropic's
+  `frontend-design` skill for a design plan (palette, type pairing, layout concept, signature
+  element) and pass it into the coder's dispatch prompt. Skipped for backend-only and
+  non-visual frontend work — zero overhead otherwise. Doesn't change the TDD cycle: tests
+  still come first, the plan only governs visual direction.
+
 ## [1.1.2] — 2026-07-02
 
 ### Fixed

--- a/plugins/bmad_v6/.claude-plugin/plugin.json
+++ b/plugins/bmad_v6/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bmad_v6",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "BMAD v6 \u2014 11-agent TDD coding pipeline (Analyst \u2192 PM \u2192 Architect \u2192 ScrumMaster \u2192 Coder \u2192 QA \u2192 Reviewer \u2192 StressTester \u2192 Tuner \u2192 Verdict \u2192 DevOps)",
   "author": {
     "name": "Luis Moro"

--- a/plugins/bmad_v6/agents/architect.md
+++ b/plugins/bmad_v6/agents/architect.md
@@ -13,6 +13,8 @@ Architect agent (Winston). Produce an Architecture Document from the PRD.
 
 > Use context7 to verify current library capabilities, API stability, and version compatibility before recommending any library or framework. Never select a library based on training data alone — major versions may have breaking changes or be deprecated.
 
+> **Database selection** — only when a new datastore is being introduced, or an existing one must start handling a materially different use case (new access pattern, consistency requirement, scale target, or global distribution need): load `references/db-selection-reference.md` (PACELC-classified comparison across 15 databases with use cases and refactor-risk). Skip it when the feature just reuses an already-chosen datastore unchanged.
+
 | Decision | Choice | Rationale | Alternatives Rejected |
 |----------|--------|-----------|----------------------|
 

--- a/plugins/bmad_v6/agents/coder-frontend.md
+++ b/plugins/bmad_v6/agents/coder-frontend.md
@@ -14,6 +14,19 @@ Nothing here overrides the core's "failing test first" rule.
 Load ONLY the `references/language-rules-reference.md` section for the story's `Language` —
 never all of them.
 
+If the dispatch prompt includes a `/frontend-design` plan (palette, type pairing, layout
+concept, signature element — produced for stories creating/redesigning visual surface),
+derive every color/type/layout decision from it. It governs visual direction; it does not
+change the TDD cycle below — tests still come first.
+
+## Design Quality (anti-AI-slop)
+Never ship, regardless of story scope: gradient text, glassmorphism as a default decoration,
+side-stripe borders as accents, the hero-metric template, identical/nested card grids, an
+eyebrow label above every section, bounce/elastic easing, or gray text on a colored
+background. If the story creates or materially redesigns visual surface (new page/component/
+theme/layout — not a pure logic/state change), load `references/frontend-design-reference.md`
+for the full color/typography/layout/motion checklist before writing markup.
+
 ## Frontend TDD — what the RED test looks like
 - **Behaviour, not markup**: Testing Library / Vitest / Jest — render, drive with `user-event`, assert observable outcome (visible text, role, state change). No tautological snapshots standing in for behavioural assertions.
 - **Accessibility is a test, not a lint afterthought**: query by role/label; assert `aria-*`, focus order, keyboard operation. A control with no accessible name fails the test.

--- a/plugins/bmad_v6/agents/qa.md
+++ b/plugins/bmad_v6/agents/qa.md
@@ -13,7 +13,7 @@ QA agent (Quinn). Input: story ACs + Amelia's test suite + implementation (trigg
 
 > **One QA, tier-aware.** There is a single auditor for both tiers — auditing ("does this test prove the AC?") is uniform; only the lens changes. Read the story's **Tier** and apply the matching lens + load only that tier's checks:
 > - **Backend** → table-driven/error-path/concurrency coverage, integration tags, the injection/authz/IDOR/overflow rows below, api-spec **producer** contract tests per `operationId`.
-> - **Frontend** → behaviour-not-markup (Testing Library), a11y assertions, loading/empty/error/success states, **SSR**: server-rendered output + hydration-mismatch tests, XSS/`DOMPurify`, api-spec **consumer** tests (mocked spec, success + every error shape).
+> - **Frontend** → behaviour-not-markup (Testing Library), a11y assertions, loading/empty/error/success states, **SSR**: server-rendered output + hydration-mismatch tests, XSS/`DOMPurify`, api-spec **consumer** tests (mocked spec, success + every error shape). For new/redesigned visual surface: spot-check against coder-frontend.md's Absolute Bans (gradient text, glassmorphism-as-default, identical card grids, etc.) — flag as MINOR/aesthetic, never a gate blocker.
 > Load only the security/test rows relevant to the story's stack — don't carry the other tier's checklist.
 
 ## Test Audit (run before the gates — this is Quinn's primary value)

--- a/plugins/bmad_v6/references/db-selection-reference.md
+++ b/plugins/bmad_v6/references/db-selection-reference.md
@@ -1,0 +1,34 @@
+# Database selection reference (PACELC)
+
+Load this **only** when a feature introduces a new datastore, or an existing datastore must
+start handling a materially different use case (new access pattern, consistency requirement,
+scale target, or global distribution need). Do not load for features that just reuse an
+already-chosen datastore unchanged — this is reference material, not part of every
+Architecture Document.
+
+**How to use**: match the feature's actual requirement — consistency vs. availability
+trade-off under partition (PACELC), data shape, and query pattern — against the table below.
+Prefer the narrowest fit; do not default to a distributed store when a single-node relational
+DB satisfies the consistency/scale requirement. Verify current version/licensing/pricing via
+context7 or web search before committing to a choice — this table is a starting shortlist,
+not a substitute for checking the vendor's current docs.
+
+| Database | PACELC | Type | Use cases | Internal mechanism | Refactorable later? | Note |
+|---|---|---|---|---|---|---|
+| Cassandra | AP / EL | Columnar | Social networks, time series, catalogs (Netflix), IoT, healthcare, platforms requiring massive write throughput, globally distributed product catalogs, 24/7 high-availability apps | Quorum | ✅ | RF/2+1 — e.g. 10/2=5+1=6 |
+| MongoDB | CP / EC | Document (ACID) | General web/mobile apps, e-commerce product catalogs, log data, rapid prototyping | Raft | ✅ | WriteConcern / ReadConcern tunable |
+| DynamoDB (AWS) | AP / EL | Key-value | High-traffic web/mobile apps, game leaderboards, user profiles, clickstreams, history, e-commerce carts, telemetry | Quorum | ✅ | Can enable strong read/write via config |
+| CockroachDB | CP / EC | Distributed relational (ACID) | Financial/banking apps needing strong ACID, global inventory management, multi-region game backends, payment processing, e-commerce (stock/orders/pricing) | Raft | ✅ | Eventual-consistency mode recently enabled |
+| SpannerDB (Google) | CP / EC | Distributed relational (ACID) | Global fintech/payments, multi-region high-scale gaming (incl. inventory/player state), mission-critical backends needing 99.999% SLA, systems needing distributed transactions with absolute consistency | Paxos | ✅ | Atomic clocks, TrueTime, Google private network, hardware control, 99.999% availability |
+| PostgreSQL | CP / EC | Single-node relational (ACID) | Web apps, enterprise systems, e-commerce, ERP, CMS, dynamic sites, systems needing strong consistency/relationships/data structure | WAL-based replication | ❌ | Single-node; depends on external tooling for distribution |
+| Redis | AP / EL | Key-value | Cache, messaging, session control | Sentinel | ❌ | Quorum ack configurable, but AP behavior doesn't change |
+| Etcd | CP / EC | Key-value | Cluster management/orchestration (Kubernetes), app/system config management, service discovery | Raft | ❌ | Fully consistency-focused; no eventual mode |
+| Riak | AP / EL | Key-value | High-traffic ad delivery, sensor data/log storage, IoT, logs, large volumes | Quorum | ⚠️ | "Strong Consistency" exists as experimental, not recommended in production |
+| Neo4j | CP / EC | Graph | Fraud detection, personalized recommendations, suspicious-activity/AML detection, social networks, real-time anomaly detection | Raft | ✅ | Runs in HA cluster mode (eventual) or strongly consistent mode |
+| Elasticsearch | CP / EC | Document | Real-time search/log analytics (ELK stack), full-text search (e-commerce, content platforms, corporate apps, internal knowledge bases) | Own mechanism (quorum-based) | ✅ | Consistency/availability tunable via `wait_for_active_shards` |
+| FoundationDB | CP / EC | Distributed transactional key-value | Metadata storage for large-scale systems, custom DB/data-model construction, iCloud (Apple CloudKit) | Paxos | ❌ | End-to-end CP; always sacrifices availability |
+| ScyllaDB | AP / EL | Columnar | High-ingestion time-series systems, online gaming/betting backends, real-time adtech/personalization, Cassandra migrations seeking extreme low latency + higher throughput (Discord) | Raft | ✅ | Tunable consistency; metadata now uses Raft (strong) |
+| Couchbase | CP / EC | Document | User profile/content management for web/mobile, high-traffic product catalogs/e-commerce, game session/player-state backends, distributed high-performance cache | Own mechanism | ✅ | Switches freely between strong-consistency and high-availability modes via config |
+| YugabyteDB | CP / EC | Distributed relational (ACID) | Mission-critical apps needing ACID + cloud-native scalability, high-performance retail/global e-commerce backends, multi-region-resilient financial systems, legacy DB migration (Oracle, PostgreSQL) to distributed architecture | Raft | ❌ | Does not support eventual consistency |
+
+Source: internal team reference table (Miro board), transcribed 2026-07-03.

--- a/plugins/bmad_v6/references/frontend-design-reference.md
+++ b/plugins/bmad_v6/references/frontend-design-reference.md
@@ -1,0 +1,55 @@
+# Frontend design quality — anti-AI-slop reference
+
+Load this only when a story creates or materially redesigns visual surface (new page,
+component, theme, or layout) — not for pure logic/state changes to existing UI, and not
+for backend/API-only stories. Condensed from [Impeccable](https://github.com/pbakaus/impeccable)
+(Apache 2.0), which itself extends Anthropic's `frontend-design` skill.
+
+## Absolute bans (match-and-refuse — rewrite on sight)
+
+- **Side-stripe borders**: `border-left`/`border-right` > 1px as a colored accent on cards/alerts. Use full borders, background tints, or icons instead.
+- **Gradient text**: `background-clip: text` + gradient. Use a solid color; emphasize via weight/size.
+- **Glassmorphism as default**: decorative blur/glass cards used everywhere. Rare and purposeful, or nothing.
+- **Hero-metric template**: big number + small label + gradient accent. SaaS cliché.
+- **Identical card grids**: same-sized icon+heading+text cards repeated endlessly. Nested cards are always wrong.
+- **Eyebrow-on-every-section**: small all-caps tracked label above every heading ("ABOUT", "PROCESS"). One deliberate brand kicker is voice; one per section is AI grammar.
+- **Numbered section markers as default scaffolding** (01/02/03 above every section) unless the section is a genuine ordered sequence.
+- **Text overflowing its container**: test heading copy at every breakpoint; reduce clamp max or rewrite copy if it overflows.
+- **Pure black/gray**: always tint neutrals toward the brand hue, even slightly.
+
+## Color
+
+- Body text contrast ≥4.5:1 against background (≥3:1 for large/bold text). Placeholder text needs the same 4.5:1 — light gray "for elegance" is the most common AI-slop tell.
+- Gray text on a colored background reads washed out — darken toward the background's own hue instead.
+- New project, no existing tokens: use OKLCH; pick a deliberate color strategy (Restrained / Committed / Full palette / Drenched) before picking colors — don't default to warm-neutral cream/sand/beige body backgrounds, that's the current saturated AI default.
+
+## Typography
+
+- Cap body line length at 65–75ch.
+- Pair fonts on a contrast axis (serif+sans, geometric+humanist) — never two similar-but-not-identical sans-serifs.
+- Hero/display heading ceiling: `clamp()` max ≤ 6rem.
+- Display letter-spacing floor: ≥ -0.04em (tighter reads cramped, not designed).
+- `text-wrap: balance` on h1–h3; `text-wrap: pretty` on long prose.
+
+## Layout
+
+- Vary spacing for rhythm — don't apply one spacing scale uniformly everywhere.
+- Cards are the lazy answer — use only when truly the best affordance.
+- Flexbox for 1D, Grid for 2D — don't default to Grid when `flex-wrap` suffices.
+- Responsive grid without breakpoints: `repeat(auto-fit, minmax(280px, 1fr))`.
+- Semantic z-index scale (dropdown → sticky → modal-backdrop → modal → toast → tooltip) — never arbitrary values like 999/9999.
+
+## Motion
+
+- Motion is part of the build, not an afterthought — plan it, don't bolt it on.
+- Don't animate CSS layout properties unless truly needed; ease out with exponential curves (`ease-out-quart`/`quint`/`expo`) — no bounce, no elastic.
+- Every animation needs a `@media (prefers-reduced-motion: reduce)` alternative (crossfade or instant).
+- Staggered list-item entrances are fine; a uniform identical fade applied to every section is the tell.
+- A reveal animation must enhance an already-visible default — never gate content visibility behind a class-triggered transition (breaks on hidden tabs / headless renders / screenshot tests).
+
+## The AI-slop test
+
+If someone could look at the interface and say "AI made that" without doubt, it failed.
+Two checks:
+- **First-order**: could someone guess the theme/palette from the category alone (e.g. every fintech is navy-and-gold)? If yes, rework the color/theme decision.
+- **Second-order**: could someone guess the aesthetic family from category-plus-anti-references (e.g. "workflow tool that's not SaaS-cream" → still lands on editorial-typographic by reflex)? If yes, the first reflex was avoided but not the second — rework again.

--- a/plugins/bmad_v6/skills/multi-agent-coding-pipeline/SKILL.md
+++ b/plugins/bmad_v6/skills/multi-agent-coding-pipeline/SKILL.md
@@ -38,7 +38,8 @@ Complete Phases 0–4 of the planning skill (Phase 5 is informational when invok
   - Backend-only story → backend coder. Frontend-only → frontend coder.
   - Full-stack story was already split by the ScrumMaster into BE + FE sub-stories sharing the `api-spec.yaml` contract (BE = producer, FE = consumer). Dispatch each to its tier coder; run BE first so the spec is real before FE consumes it.
   - If the repo/plan has no frontend stack, the frontend coder is never spawned (zero overhead).
-- Each receives: `agents/coder.md` + the tier overlay + `story-{slug}.md`
+  - **Frontend story creating or materially redesigning visual surface** (new page/component/theme/layout — not a pure logic/state change): before dispatching the frontend coder, invoke `/frontend-design` to produce a compact design plan (palette, type pairing, layout concept, signature element), then include that plan in the coder's dispatch prompt. Skip for backend-only stories and for frontend stories that don't touch visual surface (state management, data wiring, a11y-only fixes).
+- Each receives: `agents/coder.md` + the tier overlay + `story-{slug}.md` (+ the design plan, when produced)
 - The story ACs + Definition of Done are the frozen acceptance contract — Coder satisfies it, never redefines it
 - Coder runs Phase 0 Analysis, then Red→Green→Refactor: failing test first, minimum impl, refactor — owns both test and impl files
 - Coder emits `CODER DONE` (with TDD evidence: RED → GREEN) when the cycle is complete

--- a/plugins/bmad_v6/skills/task-coding-pipeline/references/loop.md
+++ b/plugins/bmad_v6/skills/task-coding-pipeline/references/loop.md
@@ -23,6 +23,7 @@ Input: Task Manifest row + Architecture → Output: `story-{slug}.md`
 
 **B. Code (TDD)** — sub-agent with `agents/coder.md` (core) + ONE tier overlay + `story-{slug}.md`
 - **Stack-aware dispatch**: pick the overlay by the sub-task's Tier — `agents/coder-backend.md` (server/API/domain) or `agents/coder-frontend.md` (UI/SSR/client). Load only the `language-rules-reference.md` section for the sub-task's `Language` — never all. Full-stack sub-tasks were split BE/FE around the `api-spec.yaml` contract (BE producer first, then FE consumer). No frontend stack → frontend coder never spawned.
+  - **Frontend sub-task creating or materially redesigning visual surface** (new page/component/theme/layout — not a pure logic/state change): before dispatching the frontend coder, invoke `/frontend-design` for a compact design plan (palette, type pairing, layout concept, signature element) and include it in the coder's dispatch prompt. Skip for backend-only sub-tasks and frontend sub-tasks that don't touch visual surface.
 - The story ACs + Definition of Done are the frozen acceptance contract — Coder satisfies it, never redefines it
 - Coder runs Phase 0 Analysis, then the Red→Green→Refactor cycle: failing test first, minimum impl, refactor — owns both test and impl files
 - Coder emits `CODER DONE` (with TDD evidence: RED → GREEN) when the cycle is complete


### PR DESCRIPTION
## Summary
- Architect (`architect.md`) loads a new PACELC-classified DB comparison (`references/db-selection-reference.md`, 15 databases) on demand — only when a feature introduces a new datastore or changes an existing one's use case.
- `coder-frontend.md` + `qa.md` gain a design-quality checklist condensed from [Impeccable](https://github.com/pbakaus/impeccable) (Apache 2.0): absolute bans inline, full color/typography/layout/motion guidance in `references/frontend-design-reference.md`, loaded only for visual-surface stories.
- `multi-agent-coding-pipeline` and `task-coding-pipeline` now invoke Anthropic's `frontend-design` skill for a design plan before dispatching the frontend coder on visual-surface stories — doesn't touch the TDD cycle, tests still come first.
- `CHANGELOG.md` updated with a `[1.2.0]` entry; `bmad_v6` plugin bumped `1.1.2` → `1.2.0`.

## Test plan
- [ ] Read-through of `architect.md`'s new Database selection note — trigger condition is clear (new datastore / different use case only)
- [ ] Read-through of `coder-frontend.md`'s Design Quality section — bans are unconditional, full reference is gated correctly
- [ ] Confirm `qa.md`'s frontend lens addition doesn't turn aesthetic findings into gate blockers
- [ ] Confirm `/frontend-design` wiring in both pipelines only fires for visual-surface stories, not backend-only or state-only frontend work
- [ ] `multi-agent-coding-pipeline/SKILL.md` still ≤100 lines (currently 98 — no more headroom, next change should move content to references/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)