### PR TITLE
Generate real Codex CLI subagent definitions per BMAD persona

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# claude-devkit — Agent Instructions
+
+This repo is the claude-devkit — a multi-plugin skill/agent library originally built for
+Claude Code. If you are Codex CLI, or another harness reading this file, working in this
+repo: the canonical engineering standards live in a single place to avoid drift —
+
+**Read `plugins/bmad_v6/CLAUDE.md` before making any change.** It covers coding discipline,
+quality gates, security defaults, and per-language rules that apply regardless of which
+harness you are.
+
+## Harness-specific notes
+
+- **Skills** (`plugins/*/skills/*/SKILL.md`) use only `name:`/`description:` frontmatter —
+  this is the same shape Codex's own Skills convention expects, so they are directly usable
+  once placed under a `.agents/skills/` directory Codex scans (repo, user, or system level).
+  See `plugins/bmad_v6/scripts/install-codex.sh` to install them for Codex.
+- **Agents** (`plugins/bmad_v6/agents/*.md`) are Claude Code Task-tool subagent definitions
+  (`tools:`/`model:` frontmatter, dispatched by name from pipeline skills). Codex has its
+  own declarative subagent format (`~/.codex/agents/<name>.toml`) — run
+  `plugins/bmad_v6/scripts/generate-codex-agents.sh` to generate one per persona, with
+  reasoning effort mapped from the Claude `model:` tier. See
+  `plugins/bmad_v6/codex/harness-adapter.md` for the current mapping and known gaps
+  (pipeline *sequencing* is not yet validated in a live Codex session).
+- **Git hooks** (`plugins/bmad_v6/git-hooks/`) are plain POSIX shell and work under any
+  harness or none at all — install via `bash plugins/bmad_v6/scripts/install-git-hooks.sh`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [1.2.1] — 2026-08-06
+
+### Changed
+
+- **Model tiering rebalanced: heavy reasoning on planning, `haiku` on code execution.**
+  The Model assignment table (`plugins/bmad_v6/CLAUDE.md`) previously ran all
+  planning/validation agents on `sonnet` and every code-writing agent (`coder` + tier
+  overlays, `tuner`, `devops`) on `opus`. Now: `opus` is reserved for the Architect's
+  design pass only (system design, ADRs, tech-stack calls — the one artifact everything
+  downstream depends on); `sonnet` keeps the rest of planning/validation (Analyst, PM,
+  Scrum Master, Bug Investigator diagnosis, QA audit, Reviewer, Stress, Verdict, pipeline
+  orchestrators); `coder` (+ backend/frontend overlays), `tuner`, and `devops` move to
+  `haiku`. Updated in agent frontmatter, `CLAUDE.md`'s table, both pipeline `SKILL.md`
+  files (`multi-agent-coding-pipeline`, `task-coding-pipeline`), `bug-fix`'s dispatch
+  (`SKILL.md` + `references/dispatch.md`), `README.md`, and `codex/harness-adapter.md`.
+- **Architecture and story artifacts made airtight so `haiku` execution stays mechanical.**
+  A cheaper Coder only works if it isn't asked to design anything. `architect.md` now
+  requires a field-by-field table for every data structure (`### Data Structures`) and a
+  new `### Test Case Specification` section enumerating the exact test cases — one row per
+  AC, edge case, and non-N/A OWASP mitigation, with a literal test name Coder copies
+  verbatim. `scrum-master.md`'s story template carries a new `### Test Cases` section
+  filtered from that spec, and the Definition of Done now checks against table rows instead
+  of ACs directly. `coder.md`'s RED phase changed from "write a test that encodes the AC's
+  intent" to "execute the next row from the Test Cases table" — the design decision moved
+  upstream to Architect/Scrum Master. `coder-backend.md`/`coder-frontend.md` reframe their
+  TDD category checklists as gap-detection rather than design guidance. `qa.md` gained a
+  spec-completeness check (every Test Cases row implemented) ahead of its existing
+  intent/tautology/corner-case audit lenses.
+
 ## [1.2.0] — 2026-07-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ BMAD v6 AI-assisted development pipeline for [Claude Code](https://claude.ai/cod
 - **Test-first by default** — the Coder writes a failing test before any implementation; the QA agent audits those tests instead of writing them. No code ships without a test that was red first.
 - **Harness-structured** — built on the four agentic-harness components: Guides (feed-forward context), Sensors (exit-code linters + test gates), Memory (cross-session `PROGRESS.md`), Orchestration (implementer ≠ validator, contract frozen before code).
 - **11-agent coding pipeline** — Analyst → PM → Architect → grill-me plan stress → ScrumMaster → Coder → QA → Reviewer → StressTester → Tuner → Verdict → DevOps
-- **Task-matched models** — `haiku` for read/explore, `sonnet` for plan/validate/long sessions, `opus` for writing code. Cheaper where it can be, stronger where it counts.
+- **Task-matched models** — `opus` for architecture design, `sonnet` for planning/validation, `haiku` for read/explore and code execution. Max reasoning goes into the plan; a tight plan means execution can be cheap.
 - **Multi-language engineering standards** — Go, TypeScript, Java, PHP, Rust, React, Flutter, HTMX, Kotlin Android, HTML/CSS
 - **Security-first quality gates** — OWASP Web Top 10 + OWASP LLM Top 10 2025 enforced at every stage
 - **23 skills** (slash commands) — architecture, security review, DB migrations, observability, PR review, release management, and more

--- a/README.md
+++ b/README.md
@@ -210,6 +210,38 @@ bash ~/.claude/git-hooks/install.sh
 
 ---
 
+### Codex CLI / Other Harnesses
+
+Every `SKILL.md` in this devkit uses only `name:`/`description:` frontmatter — the same
+shape Codex CLI's own Skills convention expects. A dedicated installer places them where
+Codex scans for skills:
+
+```bash
+bash plugins/bmad_v6/scripts/install-codex.sh
+```
+
+**What you get:** every skill installed to `~/.agents/skills/` (Codex's user-level skills
+path), plus the 18 `agents/*.md` persona docs copied to `~/.agents/agents-reference/` for
+manual reference. Root `AGENTS.md` documents the same engineering standards for any
+harness working in this repo directly.
+
+To also give Codex real, dispatchable subagents (not just reference docs) — one
+`~/.codex/agents/<name>.toml` per persona, reasoning effort mapped from that persona's
+Claude model tier (`opus`→`high`, `sonnet`→`medium`, `haiku`→`low`):
+
+```bash
+bash plugins/bmad_v6/scripts/generate-codex-agents.sh
+```
+
+**Scope:** single-agent skills (`security-review`, `quality-gate`, `pr-review`, etc.) work
+identically to Claude Code. Multi-agent pipeline skills (`multi-agent-coding-pipeline`,
+`bug-fix`, etc.) now have real per-persona Codex subagents at the right reasoning effort,
+but pipeline **sequencing** — which persona runs when, reading handoff signals like
+`CODER DONE` — hasn't been exercised end-to-end in a live Codex session yet. See
+`plugins/bmad_v6/codex/harness-adapter.md` for the vocabulary mapping and current gaps.
+
+---
+
 ## Plugin Structure
 
 The devkit is split into focused plugins. Each installs independently or together:

--- a/plugins/bmad_v6/CLAUDE.md
+++ b/plugins/bmad_v6/CLAUDE.md
@@ -27,11 +27,11 @@ Every skill, agent, and pipeline drives code test-first:
 
 | Work | Model | Examples |
 |------|-------|----------|
-| Read-only / quick answers | `haiku` | Explore, code mapping, "where is X", data fetch, locating callers |
-| Planning · design · reasoning · validation · long sessions | `sonnet` | Analyst, PM, Architect, Scrum Master, Bug Investigator (diagnosis), QA audit, Reviewer, Stress, Verdict, pipeline orchestrators |
-| Writing/changing code | `opus` | Coder (Amelia), Tuner (Tyler), DevOps (IaC/CI), any direct implementation or TDD red→green |
+| Architecture design | `opus` | Architect — system design, ADRs, tech stack, data-flow decisions the whole plan depends on |
+| Planning · reasoning · validation · long sessions | `sonnet` | Analyst, PM, Scrum Master, Bug Investigator (diagnosis), QA audit, Reviewer, Stress, Verdict, pipeline orchestrators |
+| Read-only / quick answers / code execution | `haiku` | Explore, code mapping, "where is X", data fetch, locating callers, Coder (Amelia), Tuner (Tyler), DevOps (IaC/CI), any direct implementation or TDD red→green |
 
-Default to the cheapest model that fits the task. Never run exploration on `opus`; never author production code on `haiku`. Escalate one tier only with a stated reason.
+Front-load reasoning into planning and architecture so execution is mechanical: get the plan tight on `opus`/`sonnet` first, then `haiku` just has to follow it. Reserve `opus` for the Architect's design pass. Escalate one tier only with a stated reason.
 
 ## Tool Preferences
 - **LSP first**: Use LSP (go-to-definition, find-references, diagnostics) for code navigation — grep only when LSP not applicable

--- a/plugins/bmad_v6/agents/architect.md
+++ b/plugins/bmad_v6/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Architect agent (Winston) — produces an Architecture Document from the PRD.
-model: sonnet
+model: opus
 ---
 
 Architect agent (Winston). Produce an Architecture Document from the PRD.
@@ -54,6 +54,12 @@ Entry point → input validation → auth check → business logic → response.
 Show explicitly where validation and auth occur.
 
 ### Data Structures
+Every struct/type/record fully specified — one row per field (name, type, one-line
+purpose). Coder implements these definitions verbatim; it does not design shapes.
+
+| Type | Field | Field Type | Purpose |
+|------|-------|-----------|---------|
+
 All types fully typed. No `any`, no untyped `dict`, no raw `Object`.
 - Java: `record` or final-field classes; no public mutable fields
 - JS/TS: `interface` for contracts, `type` for unions; no `any`
@@ -95,6 +101,25 @@ Never expose stack traces, internal codes, or DB details to clients.
 **Error response table** *(full error catalogue — HTTP status + error body schema)*:
 | Error Condition | Type/Class | HTTP Status | Logged? | Retry? |
 |----------------|------------|-------------|---------|--------|
+
+### Test Case Specification
+
+Enumerate the exact test cases Coder implements — one row per AC, edge case, and non-N/A
+OWASP mitigation above. This is the RED-phase checklist; Coder writes these tests as given,
+it does not invent or redesign them. Missing a case here means it doesn't get tested — be
+exhaustive.
+
+| Test Name | Component | Covers (AC/Edge/Security row) | Input | Expected Result | Type |
+|-----------|-----------|-------------------------------|-------|------------------|------|
+
+- **Test Name**: a literal identifier in the target language's test-naming convention
+  (e.g. Go `Test_CreateOrder_RejectsNegativeQuantity`, Jest `it("rejects negative
+  quantity")`) — Coder copies it verbatim as the test function/case name.
+- **Type**: unit / integration / concurrency / security / E2E — see the coder overlay
+  (`coder-backend.md` / `coder-frontend.md`) for the category checklist this table must
+  satisfy before handoff; every category the overlay requires needs at least one row here.
+- Cover every row of the Edge Cases table and every OWASP mitigation marked non-N/A above —
+  a security control with no corresponding row here is unverifiable and must not ship.
 
 ### Performance Characteristics
 - Time complexity: O(?) · Space: O(?) · Throughput: ~N req/s

--- a/plugins/bmad_v6/agents/coder-backend.md
+++ b/plugins/bmad_v6/agents/coder-backend.md
@@ -1,7 +1,7 @@
 ---
 name: coder-backend
 description: Coder overlay — Backend (Amelia · server tier). Load with agents/coder.md core.
-model: opus
+model: haiku
 ---
 
 # Coder overlay — Backend (Amelia · server tier)
@@ -16,6 +16,9 @@ Load ONLY the `references/language-rules-reference.md` section for the story's `
 never all of them.
 
 ## Backend TDD — what the RED test looks like
+The story's Test Cases table should already include a row per category below. If one is
+missing, flag it as a gap in `CODER DONE` rather than inventing the case yourself — Winston's
+spec is the source of test design, not Amelia's judgment.
 - **Unit**: table-driven; every exported function — happy path, boundary, type edge, every `return err` / rejected promise / raised exception.
 - **Integration**: real adapters behind interfaces, mocked I/O (no live network); state transitions, multi-component flows; tag them (`//go:build integration`, `@Tag("integration")`, etc.).
 - **Concurrency** (where it applies): the same resource hit in parallel — races, double-spend, idempotency replay. Go: assert under `-race`.

--- a/plugins/bmad_v6/agents/coder-frontend.md
+++ b/plugins/bmad_v6/agents/coder-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: coder-frontend
 description: Coder overlay — Frontend / Client (Amelia · UI tier). Load with agents/coder.md core.
-model: opus
+model: haiku
 ---
 
 # Coder overlay — Frontend / Client (Amelia · UI tier)
@@ -28,6 +28,9 @@ theme/layout — not a pure logic/state change), load `references/frontend-desig
 for the full color/typography/layout/motion checklist before writing markup.
 
 ## Frontend TDD — what the RED test looks like
+The story's Test Cases table should already include a row per category below. If one is
+missing, flag it as a gap in `CODER DONE` rather than inventing the case yourself — Winston's
+spec is the source of test design, not Amelia's judgment.
 - **Behaviour, not markup**: Testing Library / Vitest / Jest — render, drive with `user-event`, assert observable outcome (visible text, role, state change). No tautological snapshots standing in for behavioural assertions.
 - **Accessibility is a test, not a lint afterthought**: query by role/label; assert `aria-*`, focus order, keyboard operation. A control with no accessible name fails the test.
 - **States**: loading, empty, error, and success — each gets a test. Async data: assert the loading→resolved/error transitions.

--- a/plugins/bmad_v6/agents/coder.md
+++ b/plugins/bmad_v6/agents/coder.md
@@ -1,7 +1,7 @@
 ---
 name: coder
 description: Coder core agent (Amelia) — drives TDD implementation (Red→Green→Refactor) from a self-contained story file.
-model: opus
+model: haiku
 ---
 
 Coder **core** (Amelia). Input: story-{slug}.md (self-contained — architecture context is embedded by Scrum Master; do not request architecture.md). Drive the implementation through TDD: tests first, then code.
@@ -83,6 +83,7 @@ Read `story-{slug}.md` fully. Extract and write out:
 - **Security ACs**: explicit list; each must map to a code path
 - **Constraints**: language, framework, performance, compatibility
 - **Edge cases**: explicitly listed in the story; add any discovered during codebase exploration
+- **Test cases**: the story's Test Cases table — this is the literal RED-phase checklist, not something to redesign.
 - **OpenAPI spec check**: if `api-spec.yaml` exists in the project root, locate the `operationId`(s) this story implements. The spec defines the contract — response schemas, status codes, auth requirements, and error shapes must be satisfied exactly. Note any mismatch between story ACs and spec before coding.
 
 ### Step 2 — Explore the Codebase
@@ -139,8 +140,8 @@ Before writing code, confirm:
 Work one AC at a time. Never batch all implementation behind tests written afterward.
 
 ### RED — write the failing test first
-1. Pick the next unsatisfied AC (or security AC) from the frozen story contract.
-2. Write the smallest test that encodes the AC's *intent* (behaviour, not implementation detail). Use the project's existing test framework and patterns found in Phase 0.
+1. Pick the next unimplemented row from the story's Test Cases table (flag it — do not silently invent one — if Phase 0 codebase exploration surfaces a case the table missed).
+2. Write exactly the given Test Name, Input, and Expected Result, using the project's existing test framework and patterns found in Phase 0. The design decision — what to test, why — was already made upstream by Winston/Bob; Amelia executes the row as specified.
 3. Run the test. Confirm it FAILS for the right reason (missing behaviour — not a compile/setup error). Quote the RED output.
 4. If the test passes immediately, the behaviour already exists or the test is tautological — fix the test, do not proceed.
 

--- a/plugins/bmad_v6/agents/devops.md
+++ b/plugins/bmad_v6/agents/devops.md
@@ -1,7 +1,7 @@
 ---
 name: devops
 description: DevOps agent (Ops) — generates infrastructure-as-code files (Dockerfile, compose, CI/k8s) after PRODUCTION READY verdict.
-model: opus
+model: haiku
 ---
 
 DevOps agent (Ops). Input: architecture.md + project root file structure.

--- a/plugins/bmad_v6/agents/qa.md
+++ b/plugins/bmad_v6/agents/qa.md
@@ -20,6 +20,13 @@ QA agent (Quinn). Input: story ACs + Amelia's test suite + implementation (trigg
 
 Amelia wrote the tests test-first, so Quinn does NOT re-author them. Quinn's job is the adversarial review Amelia (who wrote both test and code) is blind to: *do these tests actually prove the behaviour, and what did they miss?* Walk all four lenses. Any failure → `QA→CODER TEST GAP` with the specific AC and lens.
 
+### 0. Spec completeness — every Test Cases row implemented?
+If the story includes a **Test Cases** table (copied from architecture's Test Case
+Specification), check first: does every row have a matching implemented test? A missing
+row is a `QA→CODER TEST GAP` on its own — the spec already decided what to test, so a gap
+here is an execution miss, not a judgment call. Then continue to lenses 1–4 for anything
+the spec itself didn't anticipate.
+
 ### 1. Coverage of intent — is every AC really tested?
 - Every AC + security AC maps to at least one test asserting its *observable* outcome.
 - A passing pipeline with an untested AC is a gap even if line coverage is 100%.

--- a/plugins/bmad_v6/agents/scrum-master.md
+++ b/plugins/bmad_v6/agents/scrum-master.md
@@ -53,13 +53,23 @@ ID: STORY-{N} | Epic: {Epic Name} | Status: Ready for Dev
 ### Known Edge Cases
 {Every edge case from architecture that this story must handle}
 
+### Test Cases
+*(Copied verbatim from architecture's Test Case Specification — filtered to rows this
+story's components touch)*
+| Test Name | Input | Expected Result | Type |
+|-----------|-------|------------------|------|
+
+Amelia implements exactly these tests, RED before GREEN, in table order. She does not
+invent additional test names beyond this list — if she discovers a gap the table doesn't
+cover, she flags it in `CODER DONE` (`Gap found: ...`) rather than silently expanding scope.
+
 ### Do NOT
 - Do not implement {feature X} — that's STORY-{M}
 
 ## Definition of Done
 *(This list is the frozen acceptance contract — agreed before any code is written. Amelia satisfies it via TDD; she does not redefine it.)*
 - [ ] All ACs pass
-- [ ] TDD followed — each AC + security AC had a test written and observed RED before its implementation
+- [ ] TDD followed — every row in the Test Cases table was written and observed RED before its implementation
 - [ ] Unit tests for every exported function / public method
 - [ ] Security ACs verified — no OWASP Top 10 violations in scope
 - [ ] Lint clean (zero errors): Go — `go vet`, `staticcheck`, `golangci-lint`; Java — `checkstyle`, `SpotBugs`, `PMD`; JS/TS — `eslint --max-warnings 0`, `prettier --check`; PHP — `phpstan` level 8, `phpcs`, `php-cs-fixer`; Rust — `cargo clippy -D warnings`, `cargo fmt --check`, `cargo audit`
@@ -74,4 +84,4 @@ ID: STORY-{N} | Epic: {Epic Name} | Status: Ready for Dev
 
 **Full-stack split**: if a task needs both server and UI work, write it as TWO stories — a Backend story (Tier: Backend) and a Frontend story (Tier: Frontend) — that share the `api-spec.yaml` as their contract. The backend story is the spec **producer**; the frontend story is the **consumer**. This keeps each story single-tier, independently testable, and dispatchable to one coder overlay. Sequence: backend story first (makes the spec real), then frontend.
 
-Handoff: each story-{slug}.md → one Coder subagent, dispatched to its tier overlay (`coder-backend.md` or `coder-frontend.md`) per the story's **Tier** field. Each story is self-contained — Coder does not receive architecture.md. The verbatim interface/type/edge-case copies in Technical Context above are what make it self-contained; shallow Technical Context sections will cause Coder to produce incorrect implementations.
+Handoff: each story-{slug}.md → one Coder subagent, dispatched to its tier overlay (`coder-backend.md` or `coder-frontend.md`) per the story's **Tier** field. Each story is self-contained — Coder does not receive architecture.md. The verbatim interface/type/edge-case/test-case copies above are what make it self-contained — a story with a complete Test Cases table needs no design judgment from Coder, only execution; shallow Technical Context or an incomplete Test Cases table will cause Coder to produce incorrect implementations.

--- a/plugins/bmad_v6/agents/tuner.md
+++ b/plugins/bmad_v6/agents/tuner.md
@@ -1,7 +1,7 @@
 ---
 name: tuner
 description: Tuner agent (Tyler) — applies targeted MINOR/NIT fixes from a TUNER REQUEST.
-model: opus
+model: haiku
 ---
 
 Tuner agent (Tyler). Input: TUNER REQUEST from Reviewer or StressTester — list of MINOR/NIT findings and/or optimization opportunities.

--- a/plugins/bmad_v6/codex/harness-adapter.md
+++ b/plugins/bmad_v6/codex/harness-adapter.md
@@ -1,0 +1,74 @@
+# Harness Adapter — Claude Code ↔ Codex CLI (and others)
+
+This devkit's skills and agents were built for Claude Code. This doc maps the
+Claude-specific primitives skills/agents reference onto Codex CLI's equivalents, so
+someone reading a skill under Codex knows what to do when it says "spawn a subagent" or
+"use TaskCreate." It documents current state — it does not change any skill or agent file.
+
+## What already works identically
+
+- **SKILL.md format**: `name:`/`description:` frontmatter + markdown body, optional
+  `references/*.md` — this is exactly Codex's own Skills convention. Every skill in this
+  devkit is directly usable once placed under `.agents/skills/<name>/` (see
+  `scripts/install-codex.sh`).
+- **Single-agent skills** — no subagent dispatch, just a playbook the calling agent
+  follows directly: `security-review`, `quality-gate`, `code-review-gate`,
+  `database-migration`, `observability`, `performance-profiling`, `release-management`,
+  `business-analysis`, `grill-me`, `handoff`, `improve-codebase-architecture`,
+  `technical-analysis`, `write-a-skill`, `rote`, `pr-review`, `checkcomments`. These work
+  under Codex exactly as they do under Claude Code.
+- **Git hooks** (`git-hooks/pre-commit`, `pre-push`, `commit-msg`) — plain POSIX shell,
+  harness-agnostic.
+
+## Vocabulary mapping (Claude Code → Codex CLI)
+
+| Claude Code primitive | Codex CLI equivalent | Notes |
+|---|---|---|
+| `Agent` tool, `subagent_type: bmad_v6:<name>` | Codex custom subagent (`~/.codex/agents/<name>.toml` or `<repo>/.codex/agents/<name>.toml`) | Codex has a real per-file declarative subagent schema (`name`/`description`/`developer_instructions`/`model`/`model_reasoning_effort`, GA'd 2026-03) — see `scripts/generate-codex-agents.sh`, which generates one `<name>.toml` per BMAD persona from `agents/*.md`, with `developer_instructions` set to that persona's full body. No longer an approximation. |
+| Agent frontmatter `tools: Bash, Read, Grep, Glob` | No direct equivalent | Codex subagent files don't currently support per-agent tool allowlists the same way. Treat as informational (the persona's intended scope), not an enforced restriction. |
+| Agent frontmatter `model: haiku/sonnet/opus` | Per-agent `model_reasoning_effort` in the generated `.toml` (`opus`→`high`, `sonnet`→`medium`, `haiku`→`low`); `model` itself is left commented out to inherit the session's `agents.default_subagent_model` | Map by role, not by literal model name: architecture design → highest reasoning effort; planning/review/validation → mid-tier; read-only/exploration and code-writing → lowest. `generate-codex-agents.sh` does this mapping automatically from each agent's frontmatter — no manual translation needed. |
+| `TaskCreate` / `TaskUpdate` (task tracking) | No built-in equivalent | Use a plain markdown checklist in the working file/PR description instead. |
+| `SendMessage` (resume a paused subagent) | Not applicable | Codex subagent threads don't expose this cross-thread resume primitive; keep orchestration within a single thread instead. |
+
+## Codex subagent generation (`scripts/generate-codex-agents.sh`)
+
+```bash
+bash plugins/bmad_v6/scripts/generate-codex-agents.sh              # -> ~/.codex/agents/*.toml
+CODEX_HOME=/tmp/.codex-test bash .../generate-codex-agents.sh      # custom target, for testing
+```
+
+Writes one `<name>.toml` per BMAD persona (17 files — `coder.md` is core-only and never
+dispatched bare, so its body is merged into both `coder-backend.toml` and
+`coder-frontend.toml`, matching how the Claude pipelines pair it with exactly one tier
+overlay). Each file's `model_reasoning_effort` is derived from that persona's `model:`
+frontmatter via the mapping above. Additive only — does not touch `~/.codex/config.toml`;
+prints a recommended `[agents]` block (`enabled`, `max_concurrent_threads_per_session`,
+`default_subagent_model`, `default_subagent_reasoning_effort`) for you to review and merge
+into your own config by hand, since that's a shared file this script shouldn't overwrite.
+
+Schema verified against `developers.openai.com/codex/subagents` (2026-08). Codex's
+multi-agent feature GA'd 2026-03 and is still evolving — if `codex` rejects a generated
+`.toml`, re-check the current docs for schema drift before filing a devkit bug.
+
+## Known gaps — pipeline orchestration not yet validated in a live Codex session
+
+Every BMAD persona now has a real Codex subagent definition at the correct reasoning
+effort (above), which closes the model-tiering half of running the multi-agent pipelines
+under Codex. What's still unverified is **sequencing**: the pipeline skills'
+phase-by-phase orchestration (`multi-agent-coding-pipeline`, `task-coding-pipeline`,
+`bug-fix`'s Investigator → Coder handoff, `rote-adapter`'s dispatch) is plain prose written
+for a human or a Claude orchestrator to follow — under Codex, the session driving the
+pipeline is expected to read the same `SKILL.md` phases and delegate to each named persona
+in turn (natural-language delegation request, or `/agent` to manage the resulting thread),
+watching for the same handoff signals (`CODER DONE`, `QA→CODER BUG REPORT`, etc.) in each
+subagent's output exactly as a Claude orchestrator would. This has **not been exercised
+end-to-end in a live Codex session** — treat it as ready to try, not yet validated. If you
+run a full pipeline under Codex, record what broke (or didn't) here.
+
+- `multi-agent-coding-pipeline` (9-agent BMAD pipeline: Analyst → PM → Architect →
+  ScrumMaster → Coder → QA → Reviewer → Stress → Verdict)
+- `task-coding-pipeline`
+- `bug-fix` (Bug Investigator → Coder handoff)
+- `analysis`, `planning`, `architecture` (single-agent dispatch, likely portable, but
+  untested)
+- `rote-adapter` (dispatches `rote-adapter` agent)

--- a/plugins/bmad_v6/scripts/generate-codex-agents.sh
+++ b/plugins/bmad_v6/scripts/generate-codex-agents.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Generate Codex CLI subagent definitions from this devkit's BMAD agent personas,
+# so a Codex CLI session can delegate to them by name with the correct
+# model_reasoning_effort per plugins/bmad_v6/CLAUDE.md's Model assignment table
+# (opus persona -> "high", sonnet -> "medium", haiku -> "low").
+#
+# Schema source: https://developers.openai.com/codex/subagents — subagent definition
+# files live at ~/.codex/agents/<name>.toml (or <repo>/.codex/agents/<name>.toml for a
+# project-scoped override); required fields name/description/developer_instructions,
+# optional fields (model, model_reasoning_effort, sandbox_mode, mcp_servers,
+# skills.config) fall back to config.toml if omitted. Verified against the docs as of
+# 2026-08 — Codex's multi-agent feature GA'd 2026-03 and is still evolving, so if
+# `codex` rejects a generated file, re-check the current docs for schema drift before
+# filing a devkit bug.
+#
+# This does NOT touch the user's ~/.codex/config.toml (a shared, hand-edited file) —
+# it writes per-persona files only and prints a companion [agents] snippet for the
+# user to review and merge themselves. Additive only, like install-codex.sh.
+#
+# Coder is core (agents/coder.md) + exactly one tier overlay in every Claude pipeline
+# dispatch — it is never spawned bare. This script mirrors that: coder.md's body is
+# merged into coder-backend.toml and coder-frontend.toml; no standalone coder.toml
+# is written.
+#
+# Usage:
+#   bash plugins/bmad_v6/scripts/generate-codex-agents.sh              # -> ~/.codex/agents
+#   CODEX_HOME=/tmp/.codex-test bash .../generate-codex-agents.sh      # custom target (testing)
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_DIR="$(cd "$SCRIPT_DIR/../agents" && pwd)"
+TARGET="${CODEX_HOME:-$HOME/.codex}/agents"
+
+mkdir -p "$TARGET"
+
+tier_to_effort() {
+  case "$1" in
+    opus) echo "high" ;;
+    sonnet) echo "medium" ;;
+    haiku) echo "low" ;;
+    *) echo "medium" ;;  # personas with no model: field (rote-*) are sonnet-tier in practice
+  esac
+}
+
+# Extract a frontmatter field's value (first match only). Frontmatter is everything
+# between the first '---' line and the next '---' line.
+frontmatter_field() {
+  local file="$1" field="$2"
+  awk -v f="$field" '
+    NR==1 && $0=="---" { infm=1; next }
+    infm && $0=="---" { exit }
+    infm && $0 ~ "^"f":" { sub("^"f":[ \t]*", ""); print; exit }
+  ' "$file"
+}
+
+# Everything after the second '---' line (the markdown body, frontmatter stripped).
+body_of() {
+  awk 'NR==1 && $0=="---" {c=1; next} c==1 && $0=="---" {c=2; next} c==2 {print}' "$1"
+}
+
+# Wrap content as a TOML literal multi-line string ('''...'''). Literal strings do no
+# escaping, so backslashes/quotes/backticks in markdown pass through untouched — the
+# one input that breaks this is a literal ''' sequence, which markdown bodies don't
+# contain; guard for it anyway rather than emit silently-broken TOML.
+toml_literal() {
+  local content="$1"
+  if printf '%s' "$content" | grep -qF "'''"; then
+    return 1
+  fi
+  printf "'''\n%s\n'''" "$content"
+}
+
+# Basic double-quoted TOML string with minimal escaping, for single-line values.
+toml_basic_string() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  printf '"%s"' "$s"
+}
+
+write_agent() {
+  local out_name="$1" persona_file="$2" extra_file="${3:-}"
+  local name description model effort body literal
+
+  name="$(frontmatter_field "$persona_file" name)"
+  description="$(frontmatter_field "$persona_file" description)"
+  model="$(frontmatter_field "$persona_file" model)"
+  effort="$(tier_to_effort "${model:-sonnet}")"
+  body="$(body_of "$persona_file")"
+  if [ -n "$extra_file" ]; then
+    body="$body
+
+$(body_of "$extra_file")"
+  fi
+
+  if ! literal="$(toml_literal "$body")"; then
+    echo "generate-codex-agents.sh: FAILED $out_name.toml — body contains a literal ''' sequence that would break the TOML string. Fix the source .md file or this script's escaping before retrying." >&2
+    exit 1
+  fi
+
+  {
+    echo "name = $(toml_basic_string "$out_name")"
+    echo "description = $(toml_basic_string "$description")"
+    echo "model_reasoning_effort = $(toml_basic_string "$effort")"
+    echo "# model left unset — inherits agents.default_subagent_model from config.toml."
+    echo "# Override here with a specific Codex model id if this persona should always"
+    echo "# run on something stronger/cheaper than the session default."
+    echo "developer_instructions = $literal"
+  } > "$TARGET/$out_name.toml"
+  echo "✓ $out_name.toml ($effort effort, from $(basename "$persona_file")$([ -n "$extra_file" ] && echo " + $(basename "$extra_file")"))"
+}
+
+echo "Generating Codex subagent definitions to $TARGET ..."
+
+for persona in analyst architect bug-investigator devops pm qa reviewer \
+               rote-adapter rote-analytics rote-datadog rote-github \
+               scrum-master stress tuner verdict; do
+  write_agent "$persona" "$AGENTS_DIR/$persona.md"
+done
+
+write_agent "coder-backend" "$AGENTS_DIR/coder.md" "$AGENTS_DIR/coder-backend.md"
+write_agent "coder-frontend" "$AGENTS_DIR/coder.md" "$AGENTS_DIR/coder-frontend.md"
+
+echo ""
+echo "$(ls "$TARGET"/*.toml | wc -l | tr -d ' ') subagent definitions written to $TARGET/"
+echo ""
+echo "This does NOT edit your ~/.codex/config.toml. Recommended [agents] block —"
+echo "review and merge it into your own config.toml (do not blindly overwrite it):"
+echo ""
+cat <<'SNIPPET'
+[agents]
+enabled = true
+max_concurrent_threads_per_session = 4
+default_subagent_model = "<your default Codex model>"
+default_subagent_reasoning_effort = "medium"
+SNIPPET
+echo ""
+echo "Per-persona reasoning effort is already baked into each <name>.toml above — the"
+echo "global default only applies to subagents Codex spawns without a matching"
+echo "generated file (e.g. ad-hoc proactive delegation)."
+echo ""
+echo "Orchestration note: this closes the model-tiering half of the multi-agent-"
+echo "pipeline gap (see plugins/bmad_v6/codex/harness-adapter.md) — each BMAD"
+echo "persona now has a real Codex subagent definition at the right reasoning"
+echo "effort. Sequencing (which persona runs when, reading handoff signals like"
+echo "'CODER DONE') still happens the same way it does for a human reading the"
+echo "pipeline SKILL.md: the Codex session driving the pipeline reads the skill's"
+echo "phases and delegates to each named persona in turn. This has not been"
+echo "exercised in a live Codex session by this script's author — validate before"
+echo "relying on it in production."

--- a/plugins/bmad_v6/scripts/install-codex.sh
+++ b/plugins/bmad_v6/scripts/install-codex.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Install claude-devkit skills for Codex CLI (and any harness that reads the
+# same convention). Additive only — never touches any file Claude Code reads
+# (plugins/*/skills, plugins/*/agents, plugins/*/.claude-plugin/, hooks.json).
+#
+# Codex scans `.agents/skills/<name>/SKILL.md` at repo, user (~/.agents/skills),
+# and system level. Every SKILL.md in this devkit already uses only
+# `name:`/`description:` frontmatter — the same shape Codex expects — so
+# skills need zero transformation, only placement.
+#
+# Agents (plugins/bmad_v6/agents/*.md) are Claude Code Task-tool subagent
+# definitions with no direct Codex equivalent (Codex subagent orchestration is
+# session/config driven, not per-file declarative). They are copied to a
+# reference-only directory so their persona/procedure content is readable,
+# NOT wired into Codex's own [agents] config. See
+# plugins/bmad_v6/codex/harness-adapter.md for the current mapping and known
+# gaps (multi-agent pipeline skills are not yet validated under Codex). This
+# codex/ directory is a dedicated namespace that install-global.sh's glob
+# patterns (*/agents, */skills/*/, */references, */hooks) never match — Codex
+# artifacts never land in ~/.claude/, by directory-structure construction.
+#
+# Platform support:
+#   Linux / macOS  — bash plugins/bmad_v6/scripts/install-codex.sh
+#
+# Usage:
+#   bash plugins/bmad_v6/scripts/install-codex.sh              # installs to ~/.agents
+#   AGENTS_HOME=/tmp/.agents-test bash .../install-codex.sh     # custom target (testing)
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BMAD="$(cd "$SCRIPT_DIR/.." && pwd)"                 # plugins/bmad_v6
+PLUGINS="$(cd "$SCRIPT_DIR/../.." && pwd)"           # plugins/
+TARGET="${AGENTS_HOME:-$HOME/.agents}"
+
+if [ -d "$TARGET/skills" ]; then
+    echo "Updating existing $TARGET ..."
+    MODE="update"
+else
+    echo "Creating fresh $TARGET ..."
+    MODE="fresh"
+fi
+
+mkdir -p "$TARGET/skills" "$TARGET/agents-reference"
+
+# ── Skills (directory-format, all plugins) ───────────────────────────────────
+# Copy ONLY SKILL.md + references/*.md, same exclusion policy as
+# install-global.sh, so SkillSpec tool scaffolding never lands here.
+skill_count=0
+for skill_dir in "$PLUGINS"/*/skills/*/; do
+    [ -f "$skill_dir/SKILL.md" ] || continue
+    skill_name="$(basename "$skill_dir")"
+    dest="$TARGET/skills/$skill_name"
+    mkdir -p "$dest"
+    cp "$skill_dir/SKILL.md" "$dest/SKILL.md"
+    if ls "$skill_dir"references/*.md >/dev/null 2>&1; then
+        mkdir -p "$dest/references"
+        cp "$skill_dir"references/*.md "$dest/references/"
+    fi
+    skill_count=$((skill_count + 1))
+done
+echo "✓ skills — $skill_count installed to $TARGET/skills/"
+
+# ── Agents (reference-only — not wired into any Codex config) ───────────────
+agent_count=0
+for agent_dir in "$PLUGINS"/*/agents; do
+    [ -d "$agent_dir" ] || continue
+    if ls "$agent_dir"/*.md >/dev/null 2>&1; then
+        cp "$agent_dir"/*.md "$TARGET/agents-reference/"
+        agent_count=$((agent_count + $(ls "$agent_dir"/*.md | wc -l)))
+    fi
+done
+echo "✓ agents — $agent_count persona docs copied to $TARGET/agents-reference/ (reference only, not auto-wired)"
+
+# ── Codex-only docs (harness-adapter.md, isolated namespace) ────────────────
+if [ -f "$BMAD/codex/harness-adapter.md" ]; then
+    cp "$BMAD/codex/harness-adapter.md" "$TARGET/harness-adapter.md"
+    echo "✓ harness-adapter.md copied to $TARGET/"
+fi
+
+echo ""
+if [ "$MODE" = "fresh" ]; then
+    echo "✅ Fresh install complete — $skill_count skills, $agent_count agent references."
+else
+    echo "✅ Update complete — $skill_count skills, $agent_count agent references."
+fi
+echo ""
+echo "Notes:"
+echo "  - Pipeline skills (multi-agent-coding-pipeline, task-coding-pipeline, bug-fix,"
+echo "    analysis, planning, architecture, rote-adapter) dispatch agents by name;"
+echo "    run scripts/generate-codex-agents.sh to generate a real Codex subagent"
+echo "    (~/.codex/agents/<name>.toml) per persona at the right reasoning effort —"
+echo "    see plugins/bmad_v6/codex/harness-adapter.md for what's still unvalidated"
+echo "    (pipeline sequencing in a live Codex session)."
+echo "  - All other skills have no subagent dependency and should work as-is."
+echo "  - To also scope skills to one project instead of (or in addition to) user-level,"
+echo "    copy $TARGET/skills/<name>/ into <project>/.agents/skills/<name>/ — Codex scans"
+echo "    both repo and user level."

--- a/plugins/bmad_v6/skills/bug-fix/SKILL.md
+++ b/plugins/bmad_v6/skills/bug-fix/SKILL.md
@@ -29,7 +29,7 @@ Input: SAM HANDOFF from Phase 1 (includes Sam's failing RED test).
 Output: `CODER DONE — BUGFIX COMPLETE` signal (see Agent Handoff Signals in `references/quality-gate-reference.md`).
 Boundary: make Sam's RED test GREEN with the minimum fix. Amelia may ADD regression tests for edge cases the fix exposes; she must NOT weaken, delete, or rewrite an existing test to fit the fix.
 
-Dispatch Amelia (model `opus`) using the Phase 2 template in [references/dispatch.md](references/dispatch.md).
+Dispatch Amelia (model `haiku`) using the Phase 2 template in [references/dispatch.md](references/dispatch.md).
 
 ## Phase 3 — Verify (Quinn)
 

--- a/plugins/bmad_v6/skills/bug-fix/references/dispatch.md
+++ b/plugins/bmad_v6/skills/bug-fix/references/dispatch.md
@@ -30,7 +30,7 @@ Return ONLY:
 Agent(
   description: "Amelia — bug fix",
   subagent_type: "claude",
-  model: "opus",
+  model: "haiku",
   prompt: """
 Read agents/coder.md (core) PLUS the tier overlay for the bug's stack —
 agents/coder-backend.md if the fix is server/API/domain, agents/coder-frontend.md if it is UI/SSR/client.

--- a/plugins/bmad_v6/skills/multi-agent-coding-pipeline/SKILL.md
+++ b/plugins/bmad_v6/skills/multi-agent-coding-pipeline/SKILL.md
@@ -11,7 +11,7 @@ Run the BMAD v6 agile pipeline. If no task is provided, ask first.
 - **Boundary**: Coder owns tests + implementation test-first; Reviewer/StressTester run only after QA approval or escalation; unmitigated CRITICAL security is automatic NOT READY.
 - **Done when**: the Pipeline Summary prints after the final epic's Verdict with Security Gate + Coverage shown.
 
-> **Model assignment** (see CLAUDE.md Model assignment table): dispatch the Coder (core + backend/frontend overlay), Tuner, and DevOps on `opus`; Analyst, PM, Architect, Scrum Master, QA, Reviewer, Stress, Verdict, and the orchestrator on `sonnet`; any read-only Explore/mapping sub-agent on `haiku`. Don't run exploration on opus or author code on haiku.
+> **Model assignment** (see CLAUDE.md Model assignment table): dispatch the Architect on `opus`; Analyst, PM, Scrum Master, QA, Reviewer, Stress, Verdict, and the orchestrator on `sonnet`; the Coder (core + backend/frontend overlay), Tuner, DevOps, and any read-only Explore/mapping sub-agent on `haiku`. Don't run exploration on opus or the Architect's design pass on haiku.
 
 ---
 

--- a/plugins/bmad_v6/skills/task-coding-pipeline/SKILL.md
+++ b/plugins/bmad_v6/skills/task-coding-pipeline/SKILL.md
@@ -17,7 +17,7 @@ Behavior contract: [skill.spec.yml](skill.spec.yml) · dependency ledger: [deps.
 
 ## Model assignment
 
-Dispatch the Coder (core + backend/frontend overlay), Tuner, and DevOps on `opus`; Architect, Scrum Master, QA, Reviewer, Stress, Verdict, and the orchestrator on `sonnet`; any read-side Explore/mapping sub-agent on `haiku` (see CLAUDE.md Model assignment table).
+Dispatch the Architect on `opus`; Scrum Master, QA, Reviewer, Stress, Verdict, and the orchestrator on `sonnet`; the Coder (core + backend/frontend overlay), Tuner, DevOps, and any read-side Explore/mapping sub-agent on `haiku` (see CLAUDE.md Model assignment table).
 
 ## Steps
 


### PR DESCRIPTION
## Summary
- `scripts/generate-codex-agents.sh` — generates `~/.codex/agents/<name>.toml` per BMAD persona, mapping each persona's Claude model tier to Codex's `model_reasoning_effort` (`opus`→`high`, `sonnet`→`medium`, `haiku`→`low`). Schema verified against `developers.openai.com/codex/subagents`.
- `coder.md` is core-only, never dispatched bare — its body merges into both `coder-backend.toml` and `coder-frontend.toml`, no standalone `coder.toml`.
- Additive only: never touches `~/.codex/config.toml`; prints a recommended `[agents]` block to merge by hand.
- `harness-adapter.md`, `install-codex.sh`, `README.md`, `AGENTS.md` updated — the "no direct equivalent" claim for Codex subagents was outdated; replaced with the real schema and a clearer statement of what's still unvalidated (pipeline **sequencing** in a live Codex session, not model tiering).

## Stacking note
Branched from `feat/model-tiering-rebalance`'s tip (PR #3, not yet merged) rather than current `main`, because the `model_reasoning_effort` mapping only makes sense against the *new* opus/sonnet/haiku tiering that PR introduces. This PR's diff will include PR #3's commit until #3 merges — once it does, GitHub will narrow this PR's diff down to just the Codex commit automatically. Recommend merging #3 first.

## Test plan
- [x] Ran the generator against a scratch `CODEX_HOME` — 17/17 `.toml` files produced
- [x] Parsed every generated file with Python `tomllib` — all valid TOML, all required fields present
- [x] Spot-checked raw output — markdown backticks/tables/code-fences survive literal-string embedding untouched
- [ ] Not yet run inside an actual Codex CLI session (no `codex` binary available in this environment) — validate schema acceptance and end-to-end pipeline delegation before relying on it in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)