### PR TITLE
feat(standards): complete the Go and Next.js language references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [2.2.0] — 2026-08-30
+
+### Added
+
+- **Go reference gained a Structure and Idiom table** — error inspection with `errors.Is` /
+  `errors.As` rather than string matching, concrete types or generics instead of
+  `interface{}` / `any`, the `cmd/` · `internal/` · `business/` · `foundation/` layout, the
+  preferred dependency set, package naming, safe zero values, `init()` avoidance, and the
+  reflection restriction. The file already named Uber Go Style and ardanlabs/service as its
+  authorities but carried none of the structural rules those authorities are consulted for.
+
+- **Next.js reference gained a bundle-growth review flag** (`@next/bundle-analyzer`).
+
+  Both gaps were found by diffing a real operator's personal `CLAUDE.md` against the shipped
+  references: 52 per-language rules were compared, and these six were the only ones the devkit
+  could not account for. They are the reason a personal standards file could not simply be
+  replaced by the devkit `@include` — the rules load on demand now, so it can.
+
 ## [2.1.1] — 2026-08-30
 
 ### Fixed

--- a/plugins/coding-pipeline/.claude-plugin/plugin.json
+++ b/plugins/coding-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "coding-pipeline",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "11-agent spec-first coding pipeline (Analyst \u2192 PM \u2192 Architect \u2192 ScrumMaster \u2192 Coder \u2192 QA \u2192 Reviewer \u2192 StressTester \u2192 Tuner \u2192 Verdict \u2192 DevOps)",
   "author": {
     "name": "Luis Moro"

--- a/plugins/coding-pipeline/references/languages/go.md
+++ b/plugins/coding-pipeline/references/languages/go.md
@@ -19,6 +19,18 @@ Gate commands: `../quality-gate-reference.md`. All languages: `../language-rules
 ## Coding Rules
 `fmt.Errorf("ctx: %w", err)` — no bare `return err`; `context.Context` first param; interfaces in consumer package; no `panic` in library code; `crypto/rand` not `math/rand`; parameterized queries; `ReadTimeout`/`WriteTimeout` on `http.Server`; `defer` for cleanup; every HTTP handler must have complete `swaggo/swag` annotations (`@Summary`, `@Description`, `@Tags`, `@Accept`, `@Produce`, `@Param`, `@Success`, `@Failure`, `@Router`); request/response types must be fully-typed Go structs (no `any`, no `interface{}`); types consumed across packages must be behind an interface in the consumer package; run `swag init ./...` — zero errors before handoff.
 
+## Structure and Idiom *(authority: [Uber Go Style](https://github.com/uber-go/guide/blob/master/style.md) → [ardanlabs/service](https://github.com/ardanlabs/service) → Effective Go)*
+| Rule | Requirement |
+|------|-------------|
+| Error inspection | `errors.Is` / `errors.As` — never string-match an error message |
+| Types | Concrete types or generics `[T any]` — never `interface{}` / `any` in a signature |
+| Layout | `cmd/` (main only) · `internal/` · `business/` · `foundation/` |
+| Dependencies | Stdlib first; then `go.uber.org/zap` · `testify` · `golang.org/x/sync` · `ardanlabs/conf/v3` |
+| Package names | Lowercase single word — no `utils` / `helpers` / `common` |
+| Zero values | Design types so the zero value is safe and usable without a constructor |
+| `init()` | Avoid unless unavoidable; never in a library package |
+| Reflection | `reflect` only for serialization libraries, with explicit justification |
+
 ## Linting Commands
 `go vet ./...` · `staticcheck ./...` · `golangci-lint run` (with `gosec`, `errcheck`, `revive` enabled)
 

--- a/plugins/coding-pipeline/references/languages/nextjs.md
+++ b/plugins/coding-pipeline/references/languages/nextjs.md
@@ -46,6 +46,7 @@ verify the flat-config blocks do not shadow one another
 | `security/*` or `regexp/*` rules absent from the config, or present at `warn` **[FH]** | MAJOR |
 | `coverageConfigDefaults.exclude` filtered in `vitest.config.*` / `jest.config.*` **[FH]** | MAJOR |
 | `.github/workflows/` file present when the project deploys through another CI system **[FH]** | MAJOR |
+| Client bundle grew without justification — check with `@next/bundle-analyzer` | MINOR |
 | coverage < 85% | BLOCK (score ≤ 5) |
 
 ---


### PR DESCRIPTION
## What

Adds a **Structure and Idiom** table to `references/languages/go.md` and a bundle-growth review flag to `nextjs.md`.

## How the gap was found

Diffed a real operator's personal `CLAUDE.md` against the shipped per-language references — 52 rules compared, 6 unaccounted for:

| Rule | Language |
|---|---|
| `errors.Is` / `errors.As` over string-matching errors | Go |
| Concrete types or generics over `interface{}` / `any` | Go |
| `cmd/` · `internal/` · `business/` · `foundation/` layout | Go |
| Preferred dependency set (zap, testify, x/sync, ardanlabs/conf) | Go |
| Package naming — no `utils` / `helpers` / `common` | Go |
| Client bundle growth via `@next/bundle-analyzer` | Next.js |

The Go file already named Uber Go Style and ardanlabs/service as its authorities while carrying none of the structural rules those are consulted for. Zero values, `init()`, and reflection were added alongside for the same reason.

## Why it matters beyond completeness

Those six rules were the only thing stopping a personal standards file from being replaced by the devkit `@include`. Keeping them inline means a full duplicate of the standards loads every session; upstreamed, they load on demand from the one language file the story needs. Re-running the coverage diff after this change: 0 unaccounted rules across all five languages.

`coding-pipeline` 2.1.1 → 2.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ6CLQDdB2fdRNCugD2Jxq