### PR TITLE
fix(gates): enforce coverage thresholds and fix Android DSL routing

### DIFF
--- a/.github/scripts/test-git-hooks.sh
+++ b/.github/scripts/test-git-hooks.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Behaviour tests for the git-hook Sensors (pre-commit / pre-push).
+#
+# CI already runs shellcheck and `bash -n` over these files, which proves they
+# parse — not that they gate. Two defect classes survive a syntax check and are
+# what this suite exists for:
+#
+#   1. Stack misrouting. A project matched by the wrong block runs another
+#      stack's tools and never reaches its own.
+#   2. A gate that prints a number it never compares, or that skips silently when
+#      the number cannot be read. Both render as a pass, which is worse than
+#      having no gate at all — the absence is at least visible.
+#
+# Every external the hooks shell out to is stubbed, so a case exercises the
+# hook's own logic and never the machine's toolchain.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOKS="$ROOT/plugins/coding-pipeline/git-hooks"
+WORK="${TMPDIR:-/tmp}/devkit-githook-tests"
+fail=0
+pass=0
+
+rm -rf "$WORK"
+
+# fixture <name> — fresh directory with every external stubbed to a silent
+# success. A case overwrites the specific stub whose output it is testing.
+fixture() {
+    local dir="$WORK/$1" bin
+    bin="$dir/.stub-bin"
+    mkdir -p "$bin"
+    for t in cargo cargo-audit cargo-tarpaulin composer mvn npx npm flutter lcov dart go govulncheck \
+             golangci-lint ktlint; do
+        printf '#!/bin/sh\nexit 0\n' > "$bin/$t"
+        chmod +x "$bin/$t"
+    done
+    printf '#!/bin/sh\nexit 0\n' > "$dir/gradlew"
+    chmod +x "$dir/gradlew"
+    printf '%s' "$dir"
+}
+
+run_hook() {        # run_hook <hook> <fixture-dir> — echoes output, returns exit code
+    local hook="$1" dir="$2"
+    ( cd "$dir" && PATH="$dir/.stub-bin:$PATH" bash "$HOOKS/$hook" 2>&1 )
+}
+
+expect_exit() {     # expect_exit <name> <hook> <fixture-dir> <want-exit>
+    local name="$1" hook="$2" dir="$3" want="$4" got
+    run_hook "$hook" "$dir" >/dev/null 2>&1; got=$?
+    if [ "$got" = "$want" ]; then
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $name — $hook exited $got, expected $want"
+        fail=1
+    fi
+}
+
+expect_says() {     # expect_says <name> <hook> <fixture-dir> <yes|no> <substring>
+    local name="$1" hook="$2" dir="$3" want="$4" needle="$5" out saw
+    out="$(run_hook "$hook" "$dir")"
+    case "$out" in *"$needle"*) saw=yes ;; *) saw=no ;; esac
+    if [ "$saw" = "$want" ]; then
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $name — expected '$needle' present=$want, got present=$saw"
+        fail=1
+    fi
+}
+
+# ── Gradle routing: `android {}` may live in either DSL ──────────────────────
+# Checking only build.gradle sends a Kotlin-DSL Android project down the Java
+# branch, where `jacocoTestReport` is not even a registered task.
+d="$(fixture kts-android)"
+printf 'android {\n}\n' > "$d/build.gradle.kts"
+mkdir -p "$d/build/reports/kover"
+printf '<report name="app"><counter type="LINE" missed="5" covered="95"/></report>\n' \
+    > "$d/build/reports/kover/report.xml"
+expect_says "kts android reaches kotlin gates"  pre-push   "$d" yes "Kotlin Android"
+expect_says "kts android skips java gates"      pre-push   "$d" no  "Java/Gradle"
+expect_says "kts android reaches detekt"        pre-commit "$d" yes "Kotlin: detekt"
+expect_says "kts android skips checkstyle"      pre-commit "$d" no  "Java/Gradle: checkstyle"
+
+d="$(fixture groovy-android)"
+printf 'android {\n}\n' > "$d/build.gradle"
+mkdir -p "$d/build/reports/kover"
+printf '<report name="app"><counter type="LINE" missed="5" covered="95"/></report>\n' \
+    > "$d/build/reports/kover/report.xml"
+expect_says "groovy android still routes to kotlin" pre-push "$d" yes "Kotlin Android"
+
+d="$(fixture plain-gradle)"
+printf 'plugins { id "java" }\n' > "$d/build.gradle"
+mkdir -p "$d/build/reports/jacoco/test"
+printf 'GROUP,PACKAGE,CLASS,IM,IC,BM,BC,LINE_MISSED,LINE_COVERED\napp,x,Foo,1,9,0,0,5,95\n' \
+    > "$d/build/reports/jacoco/test/jacocoTestReport.csv"
+expect_says "non-android gradle routes to java" pre-push "$d" yes "Java/Gradle"
+expect_says "non-android gradle skips kotlin"   pre-push "$d" no  "Kotlin Android"
+
+# ── Coverage gates must be able to fail ─────────────────────────────────────
+# Each language: one run below its declared minimum, one at or above it, and —
+# where the number is parsed out of tool output — one where it cannot be read.
+# The unreadable case is the one that silently passed before.
+
+# Rust ≥ 85%
+d="$(fixture rust-low)"
+printf '[package]\nname = "x"\n' > "$d/Cargo.toml"
+printf '#!/bin/sh\n[ "$1" = tarpaulin ] && echo "70.00%% coverage, 7/10 lines covered"\nexit 0\n' \
+    > "$d/.stub-bin/cargo"; chmod +x "$d/.stub-bin/cargo"
+expect_exit "rust below threshold blocks" pre-push "$d" 1
+
+d="$(fixture rust-ok)"
+printf '[package]\nname = "x"\n' > "$d/Cargo.toml"
+printf '#!/bin/sh\n[ "$1" = tarpaulin ] && echo "85.00%% coverage, 17/20 lines covered"\nexit 0\n' \
+    > "$d/.stub-bin/cargo"; chmod +x "$d/.stub-bin/cargo"
+expect_exit "rust at threshold passes" pre-push "$d" 0
+
+d="$(fixture rust-unreadable)"
+printf '[package]\nname = "x"\n' > "$d/Cargo.toml"
+printf '#!/bin/sh\n[ "$1" = tarpaulin ] && echo "no coverage data"\nexit 0\n' \
+    > "$d/.stub-bin/cargo"; chmod +x "$d/.stub-bin/cargo"
+expect_exit "rust unmeasured coverage blocks" pre-push "$d" 1
+
+# PHP ≥ 80%
+php_stub() {        # php_stub <fixture-dir> <lines-percent>
+    mkdir -p "$1/vendor/bin"
+    printf '#!/bin/sh\nprintf "  Lines:    %s%%%% (7/10)\\n"\nexit 0\n' "$2" > "$1/vendor/bin/phpunit"
+    chmod +x "$1/vendor/bin/phpunit"
+}
+d="$(fixture php-low)";  printf '{}\n' > "$d/composer.json"; php_stub "$d" "70.00"
+expect_exit "php below threshold blocks" pre-push "$d" 1
+d="$(fixture php-ok)";   printf '{}\n' > "$d/composer.json"; php_stub "$d" "80.00"
+expect_exit "php at threshold passes" pre-push "$d" 0
+
+# Java ≥ 85% — Maven reads JaCoCo's csv, Gradle the same file under build/
+jacoco_csv() {      # jacoco_csv <path> <missed> <covered>
+    mkdir -p "$(dirname "$1")"
+    printf 'GROUP,PACKAGE,CLASS,IM,IC,BM,BC,LINE_MISSED,LINE_COVERED\napp,x,Foo,1,9,0,0,%s,%s\n' \
+        "$2" "$3" > "$1"
+}
+d="$(fixture mvn-low)"; printf '<project/>\n' > "$d/pom.xml"
+jacoco_csv "$d/target/site/jacoco/jacoco.csv" 30 70
+expect_exit "maven below threshold blocks" pre-push "$d" 1
+
+d="$(fixture mvn-ok)"; printf '<project/>\n' > "$d/pom.xml"
+jacoco_csv "$d/target/site/jacoco/jacoco.csv" 5 95
+expect_exit "maven at threshold passes" pre-push "$d" 0
+
+d="$(fixture gradle-low)"; printf 'plugins { id "java" }\n' > "$d/build.gradle"
+jacoco_csv "$d/build/reports/jacoco/test/jacocoTestReport.csv" 30 70
+expect_exit "gradle below threshold blocks" pre-push "$d" 1
+
+# Kotlin Android ≥ 85% — Kover emits a JaCoCo-shaped xml
+kover_xml() {       # kover_xml <dir> <missed> <covered>
+    mkdir -p "$1/build/reports/kover"
+    printf '<report name="app"><counter type="LINE" missed="%s" covered="%s"/></report>\n' \
+        "$2" "$3" > "$1/build/reports/kover/report.xml"
+}
+d="$(fixture kover-low)"; printf 'android {\n}\n' > "$d/build.gradle.kts"; kover_xml "$d" 30 70
+expect_exit "kotlin below threshold blocks" pre-push "$d" 1
+d="$(fixture kover-ok)";  printf 'android {\n}\n' > "$d/build.gradle.kts"; kover_xml "$d" 5 95
+expect_exit "kotlin at threshold passes" pre-push "$d" 0
+
+# Go and Flutter already compared their numbers; neither could fail when the
+# number came back empty, which is the same hole one step later.
+d="$(fixture go-unreadable)"
+printf 'module x\n' > "$d/go.mod"
+printf '#!/bin/sh\nexit 0\n' > "$d/.stub-bin/go"; chmod +x "$d/.stub-bin/go"
+expect_exit "go unmeasured coverage blocks" pre-push "$d" 1
+
+d="$(fixture flutter-unreadable)"
+printf 'name: x\n' > "$d/pubspec.yaml"
+printf '#!/bin/sh\necho "no valid records found"\nexit 0\n' > "$d/.stub-bin/lcov"
+chmod +x "$d/.stub-bin/lcov"
+expect_exit "flutter unmeasured coverage blocks" pre-push "$d" 1
+
+rm -rf "$WORK"
+echo "git-hook tests: $pass passed, exit=$fail"
+exit $fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: hook behaviour tests
+      - name: session hook behaviour tests
         run: bash .github/scripts/test-hooks.sh
+      - name: git hook behaviour tests
+        # shellcheck proves these parse; only this proves they gate.
+        run: bash .github/scripts/test-git-hooks.sh
 
   install:
     name: install — bootstrap and settings merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## [2.2.1] — 2026-08-31
+
+### Fixed
+
+- **Coverage gates that could not fail.** `pre-push` announced "tests + coverage" for Rust,
+  PHP, Java (Maven and Gradle) and Kotlin and then compared nothing — the threshold existed
+  only in `quality-gate-reference.md`. Five languages had a declared minimum and a sensor
+  incapable of enforcing it, which reads as green. Each now parses a real number and blocks
+  below it: Rust ≥85% via `cargo tarpaulin`, PHP ≥80% from `--coverage-text`, Java ≥85% from
+  JaCoCo's csv, Kotlin Android ≥85% from Kover's xml (one parser — Kover emits JaCoCo's shape).
+
+  The same hole one step later: Go and Flutter *did* compare their numbers but passed silently
+  when the number came back empty. `coverage_gate` now refuses an unmeasured gate outright.
+  Flutter's percentage extraction also moved off `grep -oP`, which BSD grep has no PCRE for and
+  this hook ships to macOS.
+
+  Where the measuring tool is absent entirely the hooks still WARN rather than block — the
+  file's existing convention for `govulncheck` and `cargo-audit` — but the warning now says
+  UNENFORCED out loud instead of printing nothing.
+
+- **Android projects on the Kotlin DSL got no Gradle gates at all.** Both hooks detected Android
+  with `grep 'android {' build.gradle`, which fails on a `build.gradle.kts`-only project. In
+  `pre-push` the inverted copy of that test then routed such a project into the **Java** branch,
+  where `jacocoTestReport` is not a registered task; in `pre-commit` the Java block correctly
+  excluded it and the Kotlin block never claimed it, so nothing ran. One `is_android_gradle`
+  helper per hook now checks both DSLs.
+
+- **`/handoff` never wrote the one section meant to outlive the delivery.** CLAUDE.md and
+  `coding-pipeline/references/progress-file.md` define `PROGRESS.md` as
+  Done/Failed/Current State/Next/**Lessons**, and assign `Lessons` to `/handoff` explicitly.
+  The handoff skill's schema line and its own divergent copy of `progress-file.md` both stopped
+  at `Next`, so the cheapest cross-session memory the harness has was specified everywhere and
+  written nowhere. The skill now requires it, and the mirror carries the section plus the
+  precedence header the `engineering` mirror already uses (canonical wins on conflict).
+
+### Added
+
+- **`.github/scripts/test-git-hooks.sh` — 19 assertions across `pre-commit` / `pre-push`.**
+  CI ran shellcheck and `bash -n` over these files, proving they parse, never that they gate.
+  Both defect classes above survive a syntax check. Fixtures stub every external the hooks shell
+  out to, so a case exercises the hook's own logic and not the machine's toolchain; each
+  language is asserted below its minimum, at it, and — where the number is parsed from tool
+  output — with it unreadable. Wired into the `hooks` CI job.
+
+  Written RED-first against the unfixed hooks (11 failures reproducing both defects), then every
+  fix falsified in turn: the `.kts` arm removed from each helper, `coverage_gate`'s comparison
+  deleted, its empty-value guard deleted, and the Kover xml parser stubbed out — each break
+  observed to fail exactly the assertions that encode it, then restored.
+
 ## [2.2.0] — 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ autonomous agent on the rails:
 |-----------|-----------------|
 | **Guides** (feed-forward) | `CLAUDE.md`, the delivery file (`docs/deliveries/delivery-{slug}-{key}.md`), API specs, per-language standards — the right context injected before each task |
 | **Sensors** (feedback) | Linters in error-mode and test/coverage gates that return an exit code, not prose: `pre-commit` (format + lint), `pre-push` (tests + coverage ≥ 85% + vuln scan), mirrored in CI. Session-level guards run as Claude Code hooks — secrets, destructive commands, and finishing without ever running a gate. A task isn't done until they pass. |
-| **Memory** | `PROGRESS.md` at the repo root (Done / Failed / Current State / Next), every entry prefixed with its `[{delivery-key}]`. A `SessionStart` hook reads it so a new session resumes with context instead of starting blind. |
+| **Memory** | `PROGRESS.md` at the repo root (Done / Failed / Current State / Next / Lessons), every entry prefixed with its `[{delivery-key}]`. A `SessionStart` hook reads it so a new session resumes with context instead of starting blind. |
 | **Orchestration** | An orchestrator spawns isolated subagents with a pre-agreed contract. **Implementer ≠ validator** — the Coder builds, the QA/Reviewer/Stress agents validate. ACs + Definition of Done are frozen before any code. |
 
 ### Spec-first, falsification-proven
@@ -911,7 +911,8 @@ The devkit holds itself to its own Sensor bar — CI fails on an exit code, neve
 Run the same checks locally before pushing:
 
 ```bash
-bash .github/scripts/test-hooks.sh        # 30 assertions across the session guards
+bash .github/scripts/test-hooks.sh        # 37 assertions across the session guards
+bash .github/scripts/test-git-hooks.sh    # 19 assertions across pre-commit / pre-push
 bash .github/scripts/test-install.sh      # 20 assertions across the bootstrap
 python3 .github/scripts/validate-wiring.py  # manifests, hooks, and every cross-reference
 ```

--- a/plugins/coding-pipeline/.claude-plugin/plugin.json
+++ b/plugins/coding-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "coding-pipeline",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "11-agent spec-first coding pipeline (Analyst \u2192 PM \u2192 Architect \u2192 ScrumMaster \u2192 Coder \u2192 QA \u2192 Reviewer \u2192 StressTester \u2192 Tuner \u2192 Verdict \u2192 DevOps)",
   "author": {
     "name": "Luis Moro"

--- a/plugins/coding-pipeline/git-hooks/pre-commit
+++ b/plugins/coding-pipeline/git-hooks/pre-commit
@@ -5,6 +5,14 @@
 # prose for an agent to interpret.
 set -e
 
+# Android declares `android {}` in either Gradle DSL. Matching only build.gradle
+# let a Kotlin-DSL project skip the Kotlin block entirely — and the Java block
+# already excluded it — so such a project got no Gradle gates at all.
+is_android_gradle() {
+    grep -q 'android {' build.gradle 2>/dev/null \
+        || grep -q 'android {' build.gradle.kts 2>/dev/null
+}
+
 # Go
 if [ -f go.mod ]; then
     echo "→ Go: format"
@@ -63,7 +71,7 @@ fi
 # Java (Gradle)
 if [ -f build.gradle ] || [ -f build.gradle.kts ]; then
     # Skip if Android (handled by Kotlin Android block)
-    if ! grep -q 'android {' build.gradle 2>/dev/null && ! grep -q 'android {' build.gradle.kts 2>/dev/null; then
+    if ! is_android_gradle; then
         echo "→ Java/Gradle: checkstyle"
         ./gradlew checkstyleMain --quiet 2>/dev/null || true
     fi
@@ -90,7 +98,7 @@ if [ -f pubspec.yaml ]; then
 fi
 
 # Kotlin Android
-if ([ -f build.gradle ] || [ -f build.gradle.kts ]) && grep -q 'android {' build.gradle 2>/dev/null; then
+if ([ -f build.gradle ] || [ -f build.gradle.kts ]) && is_android_gradle; then
     echo "→ Kotlin: detekt"
     ./gradlew detekt --quiet
 

--- a/plugins/coding-pipeline/git-hooks/pre-push
+++ b/plugins/coding-pipeline/git-hooks/pre-push
@@ -5,6 +5,54 @@
 # passes. It returns an exit code, never prose for an agent to interpret.
 set -e
 
+# ── Sensor helpers ───────────────────────────────────────────────────────────
+# Android declares `android {}` in either Gradle DSL. Matching only build.gradle
+# routed a Kotlin-DSL project into the Java branch, where the jacoco tasks this
+# hook calls are not registered — so it never reached its own gates at all.
+is_android_gradle() {
+    grep -q 'android {' build.gradle 2>/dev/null \
+        || grep -q 'android {' build.gradle.kts 2>/dev/null
+}
+
+# coverage_gate <label> <percent> <minimum> — the comparison IS the gate.
+# An unreadable percentage fails rather than passing: a threshold that prints a
+# number it never compares, or skips when the number is missing, renders as green
+# and is worse than no gate, because the absence of one is at least visible.
+coverage_gate() {
+    local label="$1" actual="$2" min="$3"
+    if [ -z "$actual" ]; then
+        echo "FAIL: $label coverage could not be read — refusing to pass an unmeasured gate"
+        exit 1
+    fi
+    if awk "BEGIN {exit !($actual < $min)}"; then
+        echo "FAIL: $label coverage ${actual}% is below ${min}%"
+        exit 1
+    fi
+    echo "$label coverage: ${actual}% ✓"
+}
+
+# jacoco_line_pct <report>... — line coverage from the first report that exists.
+# Kover emits JaCoCo's shape, so Maven, Gradle, and Android share one parser.
+jacoco_line_pct() {
+    local f line m c
+    for f in "$@"; do
+        [ -f "$f" ] || continue
+        case "$f" in
+            *.csv)
+                awk -F, 'NR>1 {m+=$8; c+=$9} END {t=m+c; if (t>0) printf "%.1f", (c*100)/t}' "$f"
+                return 0 ;;
+            *.xml)
+                # report-level counters come last, after every package's own
+                line=$(tr '<' '\n' < "$f" | grep 'counter type="LINE"' | tail -1)
+                m=$(printf '%s' "$line" | sed -n 's/.*missed="\([0-9]*\)".*/\1/p')
+                c=$(printf '%s' "$line" | sed -n 's/.*covered="\([0-9]*\)".*/\1/p')
+                [ -n "$m$c" ] || return 0
+                awk -v m="$m" -v c="$c" 'BEGIN {t=m+c; if (t>0) printf "%.1f", (c*100)/t}'
+                return 0 ;;
+        esac
+    done
+}
+
 echo "→ Full quality gates before push..."
 
 # Go
@@ -13,12 +61,8 @@ if [ -f go.mod ]; then
     go test -race -coverprofile=/tmp/coverage.out -covermode=atomic ./...
 
     echo "→ Go: coverage ≥85%"
-    total=$(go tool cover -func=/tmp/coverage.out | tail -1 | awk '{print $3}' | tr -d '%')
-    if awk "BEGIN {exit !($total < 85)}"; then
-        echo "FAIL: coverage ${total}% is below 85%"
-        exit 1
-    fi
-    echo "Coverage: ${total}% ✓"
+    total=$(go tool cover -func=/tmp/coverage.out 2>/dev/null | tail -1 | awk '{print $3}' | tr -d '%')
+    coverage_gate "Go" "$total" 85
 
     echo "→ Go: vulnerability scan"
     if command -v govulncheck &>/dev/null; then
@@ -62,8 +106,17 @@ fi
 
 # Rust
 if [ -f Cargo.toml ]; then
-    echo "→ Rust: tests + coverage"
+    echo "→ Rust: tests"
     cargo test
+
+    echo "→ Rust: coverage ≥85%"
+    if command -v cargo-tarpaulin &>/dev/null; then
+        pct=$(cargo tarpaulin --skip-clean --out Stdout 2>/dev/null \
+                | grep -oE '[0-9]+\.[0-9]+% coverage' | tail -1 | grep -oE '[0-9]+\.[0-9]+' || true)
+        coverage_gate "Rust" "$pct" 85
+    else
+        echo "WARN: cargo-tarpaulin not found — coverage UNENFORCED. Install: cargo install cargo-tarpaulin"
+    fi
 
     echo "→ Rust: audit"
     if command -v cargo-audit &>/dev/null; then
@@ -75,25 +128,48 @@ fi
 
 # Java (Maven)
 if [ -f pom.xml ]; then
-    echo "→ Java: tests + coverage"
+    echo "→ Java: tests + coverage ≥85%"
     mvn -q verify
+
+    pct=$(jacoco_line_pct target/site/jacoco/jacoco.csv)
+    if [ -n "$pct" ]; then
+        coverage_gate "Java" "$pct" 85
+    else
+        echo "WARN: no JaCoCo csv at target/site/jacoco/jacoco.csv — coverage UNENFORCED. Add the jacoco-maven-plugin report goal."
+    fi
 
     echo "→ Java: dependency vulnerability scan"
     mvn -q dependency-check:check 2>/dev/null || echo "WARN: OWASP dep-check not configured"
 fi
 
 # Java (Gradle — non-Android)
-if ([ -f build.gradle ] || [ -f build.gradle.kts ]) && ! grep -q 'android {' build.gradle 2>/dev/null; then
-    echo "→ Java/Gradle: tests + coverage"
+if ([ -f build.gradle ] || [ -f build.gradle.kts ]) && ! is_android_gradle; then
+    echo "→ Java/Gradle: tests + coverage ≥85%"
     ./gradlew test jacocoTestReport --quiet
+
+    pct=$(jacoco_line_pct build/reports/jacoco/test/jacocoTestReport.csv)
+    if [ -n "$pct" ]; then
+        coverage_gate "Java/Gradle" "$pct" 85
+    else
+        echo "WARN: no JaCoCo csv at build/reports/jacoco/test/ — coverage UNENFORCED. Set csv.required = true on jacocoTestReport."
+    fi
 fi
 
 # PHP
 if [ -f composer.json ]; then
-    echo "→ PHP: tests + coverage"
+    echo "→ PHP: tests + coverage ≥80%"
     if [ -f vendor/bin/phpunit ]; then
-        vendor/bin/phpunit --coverage-text \
-            --coverage-filter src/ 2>/dev/null || vendor/bin/phpunit
+        php_cov="${TMPDIR:-/tmp}/devkit-phpunit-coverage.txt"
+        # --coverage-filter src/ fails on layouts without src/; fall back, but a
+        # genuinely failing suite must still stop the push.
+        if ! vendor/bin/phpunit --coverage-text --coverage-filter src/ > "$php_cov" 2>&1; then
+            vendor/bin/phpunit --coverage-text > "$php_cov" 2>&1 || { cat "$php_cov"; exit 1; }
+        fi
+        cat "$php_cov"
+        pct=$(grep -E '^[[:space:]]*Lines:' "$php_cov" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+        coverage_gate "PHP" "$pct" 80
+    else
+        echo "WARN: vendor/bin/phpunit not found — tests and coverage UNENFORCED"
     fi
 
     echo "→ PHP: audit"
@@ -106,20 +182,27 @@ if [ -f pubspec.yaml ]; then
     flutter test --coverage
 
     echo "→ Flutter: coverage ≥80%"
+    # -oE, not -oP: BSD grep has no PCRE and this hook ships to macOS too.
     if command -v lcov &>/dev/null; then
-        pct=$(lcov --summary coverage/lcov.info 2>&1 | grep 'lines' | grep -oP '\d+\.\d+(?=%)' | head -1)
-        if [ -n "$pct" ] && awk "BEGIN {exit !($pct < 80)}"; then
-            echo "FAIL: Flutter coverage ${pct}% is below 80%"
-            exit 1
-        fi
-        echo "Flutter coverage: ${pct}% ✓"
+        pct=$(lcov --summary coverage/lcov.info 2>&1 | grep 'lines' | grep -oE '[0-9]+\.[0-9]+' | head -1)
+        coverage_gate "Flutter" "$pct" 80
+    else
+        echo "WARN: lcov not found — Flutter coverage UNENFORCED. Install: brew install lcov / apt install lcov"
     fi
 fi
 
 # Kotlin Android
-if ([ -f build.gradle ] || [ -f build.gradle.kts ]) && grep -q 'android {' build.gradle 2>/dev/null; then
-    echo "→ Kotlin Android: tests + coverage"
+if ([ -f build.gradle ] || [ -f build.gradle.kts ]) && is_android_gradle; then
+    echo "→ Kotlin Android: tests + coverage ≥85%"
     ./gradlew test --quiet
+    ./gradlew koverXmlReport --quiet 2>/dev/null || true
+
+    pct=$(jacoco_line_pct build/reports/kover/report.xml)
+    if [ -n "$pct" ]; then
+        coverage_gate "Kotlin Android" "$pct" 85
+    else
+        echo "WARN: no Kover report at build/reports/kover/report.xml — coverage UNENFORCED. Apply the Kover plugin."
+    fi
 
     echo "→ Kotlin Android: lint"
     ./gradlew lint --quiet

--- a/plugins/devtools/.claude-plugin/plugin.json
+++ b/plugins/devtools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Developer tools \u2014 architectural health review, business/technical analysis, adversarial plan grilling, session handoff, skill authoring, rote adapter creation, rote flow automation",
   "author": {
     "name": "Luis Moro"

--- a/plugins/devtools/skills/handoff/SKILL.md
+++ b/plugins/devtools/skills/handoff/SKILL.md
@@ -5,13 +5,17 @@ description: 'Use when ending a long session or switching context. Compacts the 
 
 Compact the conversation into a single, standalone handoff document. Save to `/tmp/handoff-<YYYY-MM-DD-HHMMSS>.md`. Print the path and a 3-line summary.
 
-Also update the Harness memory file: write/refresh `PROGRESS.md` at the repo root (`Done` / `Failed` / `Current State` / `Next` — schema in `references/progress-file.md`). The `/tmp` handoff is the rich narrative; `PROGRESS.md` is the durable, committed state the SessionStart bootstrap hook reads next session. The two must agree.
+Also update the Harness memory file: write/refresh `PROGRESS.md` at the repo root (`Done` / `Failed` / `Current State` / `Next` / `Lessons` — schema in `references/progress-file.md`). The `/tmp` handoff is the rich narrative; `PROGRESS.md` is the durable, committed state the SessionStart bootstrap hook reads next session. The two must agree.
 
 ## Rules
 
 - Point to existing artifacts (PRD, delivery file, ADR) rather than recreating them
 - **If a delivery is in flight, record its identity first**: the `Delivery-Key`, the delivery file path, the release branch, the worktree path, and which story is next. Without the key the next session cannot resume the delivery — it will derive a fresh one and fork the work. Same for a bug fix: record the `hotfix/{slug}` branch.
 - Redact API keys, passwords, and PII
+- **Record the session's `Lessons`** — every rule the session learned the hard way, each with the
+  failure or gate output that taught it. `/handoff` is the only writer of that section, and it is
+  the one part of `PROGRESS.md` meant to outlive the delivery; a handoff that skips it discards
+  the session's most durable output. Nothing learned this session is the only valid reason to omit it.
 - The Suggested skills section is mandatory — it helps the next session start with the right tool
 - If arguments provided, tailor the document toward that next-session objective
 

--- a/plugins/devtools/skills/handoff/references/progress-file.md
+++ b/plugins/devtools/skills/handoff/references/progress-file.md
@@ -1,5 +1,10 @@
 # PROGRESS.md schema
 
+> **Canonical elsewhere.** The full schema is defined in
+> `coding-pipeline/references/progress-file.md` and **only** there. This file mirrors it so the
+> `devtools` plugin stands alone (no `coding-pipeline` dependency) — on conflict, `coding-pipeline`'s
+> copy wins; change it there first, then propagate here.
+
 `PROGRESS.md` lives at the repo root and is the durable, committed state the
 SessionStart bootstrap hook reads at the start of the next session. It must stay
 in agreement with the rich `/tmp` handoff narrative.
@@ -18,6 +23,9 @@ in agreement with the rich `/tmp` handoff narrative.
 
 ## Next
 - [Ordered next actions for the following session]
+
+## Lessons
+- [Rule learned] — evidence: [the failure or gate output that taught it] ([date])
 ```
 
 Rules:
@@ -26,3 +34,21 @@ Rules:
 - Redact secrets, tokens, and PII.
 - **Prefix every entry with the delivery key** — `` `[a8f3c1]` STORY-3 cart totals — … `` — so concurrent deliveries interleave readably in one root-level file and a resumed session can filter to its own. Bug fixes use their hotfix slug: `` `[hotfix/null-cart]` ``.
 - **Tie each `Done` item to the sensor that proves it** — the test that was falsified (and the break that made it fail), the gate that passed.
+
+## Lessons — the section that outlives the delivery
+
+`Done` / `Failed` / `Current State` / `Next` describe *this* delivery and go stale with it.
+`Lessons` is the only section meant to survive it: a rule that would have prevented a failure,
+written so a future session can apply it without re-deriving it. It is the cheapest cross-session
+memory the harness has — one line, read back automatically by the SessionStart hook — which is
+exactly why a handoff that omits it silently throws the session's most durable output away.
+
+- **A lesson is a rule, not a diary entry.** "The Stripe client needs an explicit timeout — the
+  default is infinite and the worker hung" is a lesson. "Debugged the payment worker" is not.
+- **Every lesson carries its evidence** — the error, the failing gate, the review finding that
+  produced it. A lesson with no evidence is an opinion, and opinions do not accumulate.
+- **Project-scoped by default.** A lesson that would hold in any repo belongs in the global
+  standards; promote it deliberately rather than letting it drift in here.
+- **Delete a lesson that turns out to be wrong.** A stale rule is worse than no rule — it gets
+  applied confidently.
+- **Cap it.** Past ~15 entries, fold the settled ones into the repo's conventions doc and drop them.


### PR DESCRIPTION
Fixes three findings from a full-repo consistency review. All three shared a failure mode: the artifact rendered as green while enforcing nothing.

## 1. Coverage gates that could not fail

`pre-push` printed `→ Rust: tests + coverage`, `→ Java: tests + coverage`, `→ PHP: tests + coverage` and then compared nothing. The thresholds existed only in `quality-gate-reference.md`, which calls itself the single source of truth for them — five languages had a declared minimum and a sensor incapable of enforcing it.

| Language | Minimum | Now read from |
|---|---|---|
| Rust | ≥85% | `cargo tarpaulin --out Stdout` |
| PHP | ≥80% | `phpunit --coverage-text` summary |
| Java (Maven) | ≥85% | `target/site/jacoco/jacoco.csv` |
| Java (Gradle) | ≥85% | `build/reports/jacoco/test/jacocoTestReport.csv` |
| Kotlin Android | ≥85% | `build/reports/kover/report.xml` |

One parser serves the last three — Kover emits JaCoCo's shape.

The same hole one step later: Go and Flutter *did* compare, but passed silently when the number came back empty (`[ -n "$pct" ] &&`, or `awk` erroring on an empty variable). `coverage_gate` now refuses an unmeasured gate outright. Flutter's extraction also moved off `grep -oP`, which BSD grep has no PCRE for, and this hook ships to macOS.

**Deliberate limit:** where the measuring tool is absent entirely the hooks still WARN rather than block — the file's existing convention for `govulncheck` and `cargo-audit`, and a hook that fails because a dev tool isn't installed is a hook people delete. The warning now says `UNENFORCED` out loud instead of printing nothing.

## 2. Android on the Kotlin DSL got no Gradle gates at all

Both hooks detected Android with `grep 'android {' build.gradle`, which fails on a `build.gradle.kts`-only project. In `pre-push` the inverted copy of that test then routed such a project into the **Java** branch, where `jacocoTestReport` is not a registered task. In `pre-commit` the Java block correctly excluded it and the Kotlin block never claimed it, so nothing ran. Reproduced before fixing:

```
build.gradle.kts with `android {}`  →  kotlin branch SKIPPED
                                       JAVA/GRADLE branch taken
```

One `is_android_gradle` helper per hook now checks both DSLs.

## 3. `/handoff` never wrote the section meant to outlive the delivery

CLAUDE.md and `coding-pipeline/references/progress-file.md` define `PROGRESS.md` as Done/Failed/Current State/Next/**Lessons**, and assign `Lessons` to `/handoff` by name. The handoff skill's schema line and its own divergent copy of `progress-file.md` both stopped at `Next` — so the cheapest cross-session memory the harness has was specified in three places and written by nobody. The skill now requires it, and the mirror carries the section plus the precedence header the `engineering` mirror already uses.

## The suite

CI ran shellcheck and `bash -n` over these hooks, proving they parse — never that they gate. Both defect classes above survive a syntax check.

`.github/scripts/test-git-hooks.sh`, 19 assertions, wired into the `hooks` job. Fixtures stub every external the hooks shell out to, so a case exercises the hook's own logic and not the runner's toolchain. Each language is asserted below its minimum, at it, and — where the number is parsed from tool output — with it unreadable.

**Falsification.** Written RED-first against the unfixed hooks: 11 failures reproducing defects 1 and 2. Then each fix was broken in turn and the suite observed to fail on its own assertions:

| Break | Result |
|---|---|
| `.kts` arm removed from `pre-push`'s helper | 16 passed, 3 failed |
| `.kts` arm removed from `pre-commit`'s helper | 17 passed, 2 failed |
| `coverage_gate` comparison deleted | 14 passed, 5 failed |
| `coverage_gate` empty-value guard deleted | 17 passed, 2 failed |
| Kover xml parser stubbed to return nothing | 18 passed, 1 failed |

Each break failed exactly the assertions that encode it and nothing else; all restored, 19/19 green.

One thing the falsification exposed and this PR fixes: Rust's unmeasured case originally blocked via `set -e` on a failing `grep`, not via the guard — correct exit code, no explanation. The extraction is now non-fatal so `coverage_gate` reports the reason.

## Gates

`shellcheck --severity=error` (and `warning`) · `bash -n` · JSON · `validate-wiring.py` · `test-hooks.sh` 37/37 · `test-git-hooks.sh` 19/19 · `test-install.sh` 20/20 — all green.

## Not fixed here

Same-review findings deliberately left out of scope: the `references/` path ambiguity across pipeline skills, `quality-gate-reference.md` missing its Kotlin and Flutter sections, `planning/SKILL.md`'s manifest-location contradiction, and `engineering`/`pr-workflow` version bumps that never reached the CHANGELOG. The handoff mirror's schema block also still lacks the canonical `_Last updated:_` line — only `Lessons` was in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXjpupRvFDyCfGaKWTa4e7