### PR TITLE
fix(gates): exclude .git from the duplication scan

### DIFF
--- a/.github/scripts/test-dup-attribution.sh
+++ b/.github/scripts/test-dup-attribution.sh
@@ -10,6 +10,13 @@
 # Attribution is line-level, so the case that matters most is the third one: a
 # file the delivery touched, carrying a clone in a region the diff never went
 # near. File-level attribution calls that introduced. It is not.
+#
+# Known limitation, stated rather than papered over: these cases feed the script a
+# report this file writes, and the hook cases stub jscpd entirely. That proves the
+# attribution logic and the hook's wiring — it cannot prove jscpd was *invoked*
+# correctly. An ignore-list defect (the .git/ directory being scanned, say) is
+# invisible here and only shows on a real run. Verify that by hand when the
+# invocation changes.
 set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ATTR="$ROOT/plugins/coding-pipeline/git-hooks/dup-attribution.py"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.4.1] — 2026-08-31
+
+### Fixed
+
+- **The duplication scan was reading `.git/`.** jscpd's ignore list omitted it, so git's own
+  sample hooks were counted as duplication — noise in the debt report, and a polluted denominator
+  under every percentage the gate prints. Found by running the gate end-to-end against real jscpd
+  output rather than the hand-written report fixtures the suites use: the stubbed tests prove the
+  attribution logic and the hook's wiring, but they stub the invocation itself, so an ignore-list
+  defect is structurally invisible to them. That limitation is now stated in the suite instead of
+  left to be rediscovered.
+
+
 ## [2.4.0] — 2026-08-31
 
 ### Added

--- a/plugins/coding-pipeline/.claude-plugin/plugin.json
+++ b/plugins/coding-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "coding-pipeline",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "12-agent spec-first coding pipeline (Analyst \u2192 PM \u2192 Architect \u2192 PlanReviewer \u2192 ScrumMaster \u2192 Coder \u2192 QA \u2192 Reviewer \u2192 StressTester \u2192 Tuner \u2192 Verdict \u2192 DevOps)",
   "author": {
     "name": "Luis Moro"

--- a/plugins/coding-pipeline/git-hooks/pre-push
+++ b/plugins/coding-pipeline/git-hooks/pre-push
@@ -112,7 +112,7 @@ else
     # decision, not a defect. Per-repo tuning (extra ignores, per-language limits)
     # belongs in a committed .jscpd.json, which jscpd reads without this hook knowing.
     "$jscpd_bin" . --threshold 100 --min-lines 8 --min-tokens 50 \
-        --ignore "**/node_modules/**,**/vendor/**,**/dist/**,**/build/**,**/target/**,**/.worktrees/**,**/testdata/**,**/*.lock,**/*.min.*,**/*.md" \
+        --ignore "**/.git/**,**/node_modules/**,**/vendor/**,**/dist/**,**/build/**,**/target/**,**/.worktrees/**,**/testdata/**,**/*.lock,**/*.min.*,**/*.md" \
         --reporters json --output "$dup_out" >/dev/null 2>&1 || true
 
     if base="$(dup_base)"; then


### PR DESCRIPTION
## What

jscpd's ignore list omitted `.git/`, so git's own sample hooks (`fsmonitor-watchman.sample`) were counted as duplication — noise in the pre-existing debt report, and a polluted denominator under every percentage the gate prints.

Before, on a fresh repo with two deliberately-cloned source files:

```
Pre-existing debt — not blocking, route to a follow-up (2 pair(s)):
  .git/hooks/fsmonitor-watchman.sample:70-75  ↔  .git/hooks/fsmonitor-watchman.sample:116-121
  src/legacy.js:1-6  ↔  src/legacy2.js:1-6
```

After: only the real pair, and the percentages are measured against source lines alone.

## How it was found — and why the tests missed it

By running the gate end-to-end against **real jscpd output**, rather than the hand-written report fixtures both suites use.

That is the honest limitation: `test-dup-attribution.sh` feeds the script a report the test file writes, and `test-git-hooks.sh` stubs jscpd entirely. Together they prove the attribution logic and the hook's wiring — which is what they were written for — but they stub the *invocation*, so an ignore-list defect is structurally invisible to them. No assertion I could add to a stubbed suite would have caught this without becoming a tautology about the hook's own source text.

So the limitation is now recorded in the suite header instead of being left for the next person to rediscover, and the end-to-end check is the thing to repeat when the invocation changes.

Verified after the fix, end to end with real jscpd: a pre-existing clone passes and is reported as debt; a clone the delivery copy-pastes blocks and names both locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BD7gUMhMRJ1d4STM8QXLRp