### PR TITLE
fix(tests): isolate hook tests from the machine's PATH; document both install routes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,29 +1,29 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "claude-devkit",
-  "description": "Spec-first AI development harness — Go/TS/Java/PHP/Rust multi-language engineering standards, OWASP security gates, falsification-gated coding pipelines, 23 skills",
+  "description": "Spec-first AI development harness \u2014 Go/TS/Java/PHP/Rust multi-language engineering standards, OWASP security gates, falsification-gated coding pipelines, 23 skills",
   "owner": {
     "name": "Luis Moro"
   },
   "plugins": [
     {
       "name": "coding-pipeline",
-      "description": "11-agent spec-first coding pipeline (Analyst → PM → Architect → ScrumMaster → Coder → QA → Reviewer → StressTester → Tuner → Verdict → DevOps)",
+      "description": "12-agent spec-first coding pipeline (Analyst \u2192 PM \u2192 Architect \u2192 PlanReviewer \u2192 ScrumMaster \u2192 Coder \u2192 QA \u2192 Reviewer \u2192 StressTester \u2192 Tuner \u2192 Verdict \u2192 DevOps)",
       "source": "./plugins/coding-pipeline"
     },
     {
       "name": "engineering",
-      "description": "Engineering quality skills — security review, quality gates, DB migration, observability, performance profiling, release management",
+      "description": "Engineering quality skills \u2014 security review, quality gates, DB migration, observability, performance profiling, release management",
       "source": "./plugins/engineering"
     },
     {
       "name": "pr-workflow",
-      "description": "PR workflow skills — full code review and PR comment listing",
+      "description": "PR workflow skills \u2014 full code review and PR comment listing",
       "source": "./plugins/pr-workflow"
     },
     {
       "name": "devtools",
-      "description": "Developer tools — architectural analysis, business/technical mapping, grill-me, handoff, skill authoring, rote automation",
+      "description": "Developer tools \u2014 architectural analysis, business/technical mapping, grill-me, handoff, skill authoring, rote automation",
       "source": "./plugins/devtools"
     }
   ]

--- a/.github/scripts/test-git-hooks.sh
+++ b/.github/scripts/test-git-hooks.sh
@@ -38,9 +38,16 @@ fixture() {
     printf '%s' "$dir"
 }
 
+# Deliberately NOT the caller's PATH. Prepending the stub dir to it leaves the real
+# tools reachable further down, so a case asserting a tool is *absent* silently
+# starts testing the machine instead of the hook — these tests passed until jscpd
+# was installed on the author's box, then failed for a reason having nothing to do
+# with the hook. /usr/bin and /bin carry git, python3 and the coreutils the hooks
+# need; everything optional lives in /usr/local, /opt/homebrew or an npm prefix and
+# stays out of reach unless a fixture stubs it explicitly.
 run_hook() {        # run_hook <hook> <fixture-dir> — echoes output, returns exit code
     local hook="$1" dir="$2"
-    ( cd "$dir" && PATH="$dir/.stub-bin:$PATH" bash "$HOOKS/$hook" 2>&1 )
+    ( cd "$dir" && PATH="$dir/.stub-bin:/usr/bin:/bin" bash "$HOOKS/$hook" 2>&1 )
 }
 
 expect_exit() {     # expect_exit <name> <hook> <fixture-dir> <want-exit>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [2.4.3] — 2026-08-31
+
+### Fixed
+
+- **`test-git-hooks.sh` was testing the machine, not the hook.** `run_hook` prepended the stub
+  directory to the *caller's* `PATH`, leaving the real binaries reachable further down — so every
+  case asserting a tool is absent silently depended on that tool not being installed. The suite was
+  green until `jscpd` was installed on the author's machine, then failed nine assertions for a
+  reason with nothing to do with the hooks. It now runs against `<stubs>:/usr/bin:/bin`, which
+  carries git, python3 and the coreutils the hooks need while keeping anything from
+  `/usr/local`, `/opt/homebrew` or an npm prefix out of reach unless a fixture stubs it explicitly.
+  Verified green both with `jscpd` installed and with it hidden, and falsified by reverting to the
+  caller's `PATH`.
+
+- **`install.sh --dry-run` printed `npm install -gjscpd`** — a copy-pasteable command missing its
+  space. The real install path was always correct; only the dry-run message was wrong.
+
+### Changed
+
+- **The engineering standards are no longer `@`-imported by the repo's own `CLAUDE.md`.** Anyone
+  who installed the devkit already has that identical file imported globally, so working on the
+  devkit itself loaded ~6,560 tokens of it twice per session. The repo file now points at the
+  canonical path and tells an uninstalled contributor how to get it. This changes nothing for any
+  other repository, where the file was only ever loaded once.
+
+- **Both install routes documented as first-class, with their difference stated honestly.** A
+  Claude Code plugin cannot write to `.git/hooks/` and cannot ship a `CLAUDE.md`. The skills and
+  agents restate inline the rules they depend on, so the plugin route works correctly standalone —
+  what it does not carry is the repo-wide contract (Coding Discipline, Proportionality, Security
+  Defaults, and the objectives that break ties). The README now says so and gives the three lines
+  that add it, alongside `install.sh` for a machine configured end to end. Neither route is going
+  away.
+
+- `marketplace.json` still described an 11-agent pipeline without the Plan Reviewer.
+
+
 ## [2.4.2] — 2026-08-31
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,13 @@
 # claude-devkit — Project Memory
 
-This repository **is** the claude-devkit. To avoid drift, the engineering standards are
-maintained in a single canonical place — the `coding-pipeline` plugin's `CLAUDE.md` (the same file
-`scripts/install-global.sh` ships to `~/.claude/devkit/CLAUDE.md`). It is included below and
-applies when working in this repo too.
+This repository **is** the claude-devkit. The engineering standards live in exactly one file —
+[`plugins/coding-pipeline/CLAUDE.md`](plugins/coding-pipeline/CLAUDE.md) — which is what
+`scripts/install-global.sh` ships to `~/.claude/devkit/CLAUDE.md`.
 
-@plugins/coding-pipeline/CLAUDE.md
+**They are deliberately not `@`-imported here.** Anyone who installed the devkit already has that
+same file imported globally, so importing it again would load ~6.5k tokens of identical content
+twice in every session spent working on the devkit itself — and the standards' own first rule is
+that an addition must earn its tokens.
+
+If you are contributing here **without** the devkit installed, install it (`bash install.sh`) or
+read `plugins/coding-pipeline/CLAUDE.md` directly — it is the contract this repo is built to.

--- a/README.md
+++ b/README.md
@@ -237,7 +237,26 @@ marketplace manage it, do that yourself in Claude Code:
 /plugin install coding-pipeline@claude-devkit
 ```
 
-Git hooks still need the step below — a plugin cannot write to `.git/hooks/`.
+**Two things the plugin manager cannot do**, by design of the plugin format — both easy to add:
+
+1. **Git hooks.** A plugin cannot write to `.git/hooks/`, so run the step below per repo.
+2. **The engineering standards file.** A plugin cannot ship a `CLAUDE.md`. The skills and agents
+   are written to stand alone — each one restates inline the rules it depends on (model
+   assignment, gate thresholds, the acceptance contract), so **the plugin route works correctly on
+   its own**. What you do not get is the repo-wide contract: Coding Discipline, Proportionality,
+   Security Defaults, and the objectives that break ties between them. To add it, put the standards
+   where your global config can see them:
+
+   ```bash
+   mkdir -p ~/.claude/devkit
+   cp <checkout>/plugins/coding-pipeline/CLAUDE.md ~/.claude/devkit/CLAUDE.md
+   printf '\n@~/.claude/devkit/CLAUDE.md\n' >> ~/.claude/CLAUDE.md
+   ```
+
+   Or just run `bash install.sh`, which does exactly this and keeps it current.
+
+Both routes are supported and neither is going away: use the plugin manager if you want it to
+manage versions, use `install.sh` if you want a machine configured end to end.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -201,7 +201,7 @@ install_gate_tools() {
         warn "npm not found — duplication gate stays UNENFORCED (needs:$missing)"
         return 0
     fi
-    if [ "$DRY_RUN" = "1" ]; then say "  would run: npm install -g$missing"; return 0; fi
+    if [ "$DRY_RUN" = "1" ]; then say "  would run: npm install -g $missing"; return 0; fi
     say "  the duplication gate (≤3%) needs:$missing"
     if confirm "install with npm?"; then
         for t in $missing; do

--- a/plugins/coding-pipeline/.claude-plugin/plugin.json
+++ b/plugins/coding-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "coding-pipeline",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "12-agent spec-first coding pipeline (Analyst \u2192 PM \u2192 Architect \u2192 PlanReviewer \u2192 ScrumMaster \u2192 Coder \u2192 QA \u2192 Reviewer \u2192 StressTester \u2192 Tuner \u2192 Verdict \u2192 DevOps)",
   "author": {
     "name": "Luis Moro"


### PR DESCRIPTION
## The test bug, found by fixing something else

`run_hook` prepended the stub directory to the **caller's** `PATH`, which leaves the real binaries reachable further down it. So every case asserting a tool is *absent* was asserting something about the machine, not about the hook.

The suite was green for two releases — until `jscpd` was installed on this machine, at which point nine assertions failed for a reason entirely unrelated to the code under test:

```
FAIL: missing jscpd does not block — pre-push exited 1, expected 0
FAIL: rust at threshold passes — pre-push exited 1, expected 0
… 7 more
```

Now scoped to `<stubs>:/usr/bin:/bin` — git, python3 and the coreutils the hooks need are there, while `/usr/local`, `/opt/homebrew` and npm prefixes stay out of reach unless a fixture stubs them explicitly.

**Verified both ways**, which is the point: green with `jscpd` installed, and green with it hidden from `PATH` entirely. Falsified by reverting to the caller's `PATH` — reproduces the nine failures exactly.

This is the same defect class the suite's own header warns about: a gate that passes for the wrong reason. It just happened to be in the tests rather than the hooks.

## The double-loaded CLAUDE.md

`install.sh` imports `~/.claude/devkit/CLAUDE.md` into your global config, so it applies in every repo. This repo *also* `@`-imported its own copy — identical content, **~6,560 tokens loaded twice per session**, but only when working on the devkit itself.

The repo file now points at the canonical path instead, and tells a contributor without the devkit installed how to get it. **No other repository is affected** — the file was only ever loaded once there.

## Both install routes, stated honestly

A Claude Code plugin cannot write to `.git/hooks/` and cannot ship a `CLAUDE.md`. Rather than pretend otherwise:

- The skills and agents **restate inline** the rules they depend on (model assignment, gate thresholds, the acceptance contract), so the **plugin route works correctly standalone** — verified, not assumed.
- What it does not carry is the repo-wide contract: Coding Discipline, Proportionality, Security Defaults, and the objectives that break ties between them. The README now gives the three lines that add it.

Both routes are supported and neither is going away: the plugin manager if you want it to manage versions, `install.sh` for a machine configured end to end.

## Also

- `install.sh --dry-run` printed `npm install -gjscpd` — a copy-pasteable command missing its space. The real install path was always correct.
- `marketplace.json` still advertised an 11-agent pipeline without the Plan Reviewer.

CI: shellcheck · JSON · wiring (152 links) · 27 git-hook · 11 attribution · 37 session-hook · 20 install — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BD7gUMhMRJ1d4STM8QXLRp